### PR TITLE
refactor: fix some internal naming conventions and add more documentation

### DIFF
--- a/python/src/brrr/app.py
+++ b/python/src/brrr/app.py
@@ -16,15 +16,25 @@ from brrr.store import NotFoundError
 from .codec import Codec
 from .connection import Connection, Defer, DeferredCall, Request, Response
 
-type Task[C, **P, R] = Callable[Concatenate[C, P], Awaitable[R]]
+# Any async function of P returning R.  The structural primitive Task is built
+# from, and the shape callers get back from schedule/read/call: the task's own
+# arguments, with the environment already supplied.
+type AsyncFn[**P, R] = Callable[P, Awaitable[R]]
+
+# A brrr task: a user function which receives its environment as its first
+# argument, followed by the task's own arguments.  Env is supplied by the Codec,
+# which decides what to inject on every invocation.  Usually that's an
+# ActiveWorker, so the task can call back into brrr, but a codec is free to
+# provide anything.
+type Task[Env, **P, R] = AsyncFn[Concatenate[Env, P], R]
 
 RootId = NewType("RootId", str)
 
 
 @dataclass
-class Registry[C]:
-    codec: Codec[C]
-    handlers: TaskCollection[C]
+class Registry[Env]:
+    codec: Codec[Env]
+    handlers: TaskCollection[Env]
 
 
 class NotInBrrrError(Exception):
@@ -40,23 +50,23 @@ def _val2key[K, V](d: Mapping[K, V], val: V) -> K:
     raise KeyError(val)
 
 
-class TaskCollection[C](UserDict[str, Task[C, ..., Any]]):
-    def task2name(self, task: Task[C, ..., Any]) -> str:
+class TaskCollection[Env](UserDict[str, Task[Env, ..., Any]]):
+    def task2name(self, task: Task[Env, ..., Any]) -> str:
         return _val2key(self, task)
 
-    def spec2name(self, spec: str | Task[C, ..., Any]) -> str:
+    def spec2name(self, spec: str | Task[Env, ..., Any]) -> str:
         return spec if isinstance(spec, str) else self.task2name(spec)
 
 
-class AppConsumer[C]:
+class AppConsumer[Env]:
     _connection: Connection
-    _registry: Registry[C]
+    _registry: Registry[Env]
 
     def __init__(
         self,
-        codec: Codec[C],
+        codec: Codec[Env],
         connection: Connection,
-        handlers: Mapping[str, Task[C, ..., Any]] | None = None,
+        handlers: Mapping[str, Task[Env, ..., Any]] | None = None,
     ):
         self._connection = connection
         self._registry = Registry(codec, TaskCollection(handlers or {}))
@@ -64,15 +74,13 @@ class AppConsumer[C]:
     @overload
     def schedule[**P, R](
         self,
-        task_spec: Task[C, P, R],
+        task_spec: Task[Env, P, R],
         *,
         topic: str,
-    ) -> Callable[P, Awaitable[None]]: ...
+    ) -> AsyncFn[P, None]: ...
     @overload
-    def schedule(
-        self, task_spec: str, *, topic: str
-    ) -> Callable[..., Awaitable[None]]: ...
-    def schedule(self, task_spec: Any, *, topic: str) -> Callable[..., Awaitable[None]]:
+    def schedule(self, task_spec: str, *, topic: str) -> AsyncFn[..., None]: ...
+    def schedule(self, task_spec: Any, *, topic: str) -> AsyncFn[..., None]:
         """Public-facing one-shot schedule method."""
         task_name = self._registry.handlers.spec2name(task_spec)
 
@@ -85,10 +93,10 @@ class AppConsumer[C]:
         return f
 
     @overload
-    def read[**P, R](self, task_spec: Task[C, P, R]) -> Callable[P, Awaitable[R]]: ...
+    def read[**P, R](self, task_spec: Task[Env, P, R]) -> AsyncFn[P, R]: ...
     @overload
-    def read(self, task_spec: str) -> Callable[..., Awaitable[Any]]: ...
-    def read(self, task_spec: Any) -> Callable[..., Awaitable[Any]]:
+    def read(self, task_spec: str) -> AsyncFn[..., Any]: ...
+    def read(self, task_spec: Any) -> AsyncFn[..., Any]:
         task_name = self._registry.handlers.spec2name(task_spec)
 
         async def f(*args: Any, **kwargs: Any) -> Any:
@@ -99,7 +107,7 @@ class AppConsumer[C]:
         return f
 
 
-class AppWorker[C](AppConsumer[C]):
+class AppWorker[Env](AppConsumer[Env]):
     async def handle(self, request: Request, conn: Connection) -> Response | Defer:
         """Glue between this class and the underlying Connection.loop handler"""
         task_name = request.call.task_name
@@ -115,15 +123,15 @@ class AppWorker[C](AppConsumer[C]):
         return Response(payload=resp)
 
 
-class ActiveWorker[C]:
+class ActiveWorker[Env]:
     _connection: Connection
-    _registry: Registry[C]
+    _registry: Registry[Env]
     # Exposed only for reference sake of the handler of a call; changing this
     # value has no effect on how this class behaves.  This class’ implementation
     # does not read nor care about this value.
     root_id: Final[RootId]
 
-    def __init__(self, conn: Connection, registry: Registry[C], root_id: RootId):
+    def __init__(self, conn: Connection, registry: Registry[Env], root_id: RootId):
         self._connection = conn
         self._registry = registry
         self.root_id = root_id
@@ -131,17 +139,15 @@ class ActiveWorker[C]:
     @overload
     def call[**P, R](
         self,
-        task_spec: Task[C, P, R],
+        task_spec: Task[Env, P, R],
         *,
         topic: str | None = None,
-    ) -> Callable[P, Awaitable[R]]: ...
+    ) -> AsyncFn[P, R]: ...
     @overload
     def call(
         self, task_spec: str, *, topic: str | None = None
-    ) -> Callable[..., Awaitable[Any]]: ...
-    def call(
-        self, task_spec: Any, *, topic: str | None = None
-    ) -> Callable[..., Awaitable[Any]]:
+    ) -> AsyncFn[..., Any]: ...
+    def call(self, task_spec: Any, *, topic: str | None = None) -> AsyncFn[..., Any]:
         """Directly call a brrr task from within another task.
 
         Do not call this unless you are, yourself, already inside a brrr task.

--- a/python/src/brrr/codec.py
+++ b/python/src/brrr/codec.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
     from brrr.app import ActiveWorker, Task
 
 
-class Codec[C](ABC):
+class Codec[Env](ABC):
     """Codec for values that pass around the brrr datastore.
 
     If you want inter-language calling you'll need to ensure both languages
@@ -33,8 +33,8 @@ class Codec[C](ABC):
     async def invoke_task(
         self,
         call: Call,
-        task: Task[C, ..., Awaitable[Any]],
-        active_worker: ActiveWorker[C],
+        task: Task[Env, ..., Awaitable[Any]],
+        active_worker: ActiveWorker[Env],
     ) -> bytes:
         raise NotImplementedError()
 

--- a/python/src/brrr/local_app.py
+++ b/python/src/brrr/local_app.py
@@ -1,21 +1,21 @@
 import functools
 from collections.abc import AsyncIterator, Mapping
 from contextlib import asynccontextmanager
-from typing import Any, Awaitable, Callable
+from typing import Any
 
-from .app import AppWorker, Task
+from .app import AppWorker, AsyncFn, Task
 from .backends.in_memory import CloseOnEmptyQueue, InMemoryByteStore
 from .codec import Codec
 from .connection import Server, serve
 
 
-class LocalApp[C]:
+class LocalApp[Env]:
     """
     Low(er)-level primitive for local dev, mimics App* types.
     """
 
     def __init__(
-        self, *, topic: str, conn: Server, queue: CloseOnEmptyQueue, app: AppWorker[C]
+        self, *, topic: str, conn: Server, queue: CloseOnEmptyQueue, app: AppWorker[Env]
     ) -> None:
         self._conn = conn
         self._app = app
@@ -33,9 +33,9 @@ class LocalApp[C]:
 
 
 @asynccontextmanager
-async def local_app[C](
-    topic: str, handlers: Mapping[str, Task[C, ..., Any]], codec: Codec[C]
-) -> AsyncIterator[LocalApp[C]]:
+async def local_app[Env](
+    topic: str, handlers: Mapping[str, Task[Env, ..., Any]], codec: Codec[Env]
+) -> AsyncIterator[LocalApp[Env]]:
     """
     Helper function for unit tests which use brrr
     """
@@ -47,7 +47,7 @@ async def local_app[C](
         yield LocalApp(topic=topic, conn=conn, queue=queue, app=app)
 
 
-class LocalBrrr[C]:
+class LocalBrrr[Env]:
     """Helper class for your unit tests to use an ephemeral in-memory brrr.
 
     >>> import asyncio
@@ -65,13 +65,13 @@ class LocalBrrr[C]:
     """
 
     def __init__(
-        self, topic: str, handlers: Mapping[str, Task[C, ..., Any]], codec: Codec[C]
+        self, topic: str, handlers: Mapping[str, Task[Env, ..., Any]], codec: Codec[Env]
     ):
         self.topic = topic
         self.handlers = handlers
         self.codec = codec
 
-    def run[**P, R](self, f: Task[C, P, R] | str) -> Callable[P, Awaitable[R]]:
+    def run[**P, R](self, f: Task[Env, P, R] | str) -> AsyncFn[P, R]:
         """Create an ephemeral brrr app and runt his entire task to completion.
 
         Named `run' to emphasize this is different from app.call.  This isn't

--- a/typescript/src/app.ts
+++ b/typescript/src/app.ts
@@ -8,24 +8,62 @@ import {
 import type { Codec } from "./codec.ts";
 import { NotFoundError, TaskNotFoundError } from "./errors.ts";
 
-export type Task<C, A extends unknown[] = any[], R = any> = NoContextTask<
-  [C, ...A],
+/**
+ * A brrr task: a user function which receives its environment as its first
+ * argument, followed by the task's own arguments.
+ *
+ * `Env` is supplied by the {@link Codec}, which decides what to inject on every
+ * invocation.  Usually that's an {@link ActiveWorker}, so the task can call
+ * back into brrr, but a codec is free to provide anything.
+ */
+export type Task<Env, A extends unknown[] = any[], R = any> = AsyncFn<
+  [Env, ...A],
   R
 >;
 
-export type NoContextTask<A extends unknown[] = any[], R = any> = (
+/**
+ * Any function of `A` returning `R`, sync or async.
+ *
+ * The structural primitive {@link Task} is built from, and the shape callers
+ * get back from `schedule`/`read`/`call`: the task's own arguments, with the
+ * environment already supplied.
+ */
+export type AsyncFn<A extends unknown[] = any[], R = any> = (
   ...args: A
 ) => R | Promise<R>;
 
-export type Handlers<C> = Readonly<Record<string, Task<C, any[], any>>>;
+/**
+ * The tasks a worker knows how to run, keyed by task name.
+ *
+ * The name is what travels over the wire, so it must be stable across every
+ * worker serving a topic.
+ */
+export type Handlers<Env> = Readonly<Record<string, Task<Env, any[], any>>>;
 
-export type Registry<C> = {
-  codec: Codec<C>;
-  handlers: Handlers<C>;
+/**
+ * Everything needed to translate between brrr's bytes and user-facing calls:
+ * the codec which does the encoding, and the tasks it can encode for.
+ */
+export type Registry<Env> = {
+  codec: Codec<Env>;
+  handlers: Handlers<Env>;
 };
 
-export type TaskIdentifier<C, A extends unknown[], R> = Task<C, A, R> | string;
+/**
+ * A task, referred to either by the function itself or by its registered name.
+ *
+ * Passing the function is nicer to write and keeps argument types; passing the
+ * name lets you refer to tasks this process doesn't implement.
+ */
+export type TaskIdentifier<Env, A extends unknown[], R> =
+  | Task<Env, A, R>
+  | string;
 
+/**
+ * Resolve a {@link TaskIdentifier} to the task name used on the wire.
+ *
+ * @throws {TaskNotFoundError} if the function isn't registered in `handlers`.
+ */
 export function taskIdentifierToName(
   identifier: TaskIdentifier<any, any[], any>,
   handlers: Handlers<any>,
@@ -41,21 +79,35 @@ export function taskIdentifierToName(
   throw new TaskNotFoundError(identifier.name);
 }
 
-export class AppConsumer<C> {
+/**
+ * The client-facing half of a brrr app: schedule tasks and read their results.
+ *
+ * This is the typed, codec-aware layer on top of {@link Connection}.  Like the
+ * connection it wraps, it cannot _run_ tasks and it cannot use the
+ * defer-and-retry mechanism; that's {@link AppWorker}.
+ */
+export class AppConsumer<Env> {
   public readonly connection: Connection;
-  public readonly registry: Registry<C>;
+  public readonly registry: Registry<Env>;
 
   public constructor(
-    codec: Codec<C>,
+    codec: Codec<Env>,
     connection: Connection,
-    handlers: Handlers<C> = {},
+    handlers: Handlers<Env> = {},
   ) {
     this.connection = connection;
     this.registry = { codec, handlers };
   }
 
+  /**
+   * Public-facing one-shot schedule method.
+   *
+   * Returns a function which, when called with the task's arguments, encodes
+   * the call and puts it on `topic`.  Scheduling is fire-and-forget: it
+   * resolves once the job is queued, not once the task has run.
+   */
   public schedule<A extends unknown[], R>(
-    taskIdentifier: TaskIdentifier<C, A, R>,
+    taskIdentifier: TaskIdentifier<Env, A, R>,
     topic: string,
   ): (...args: A) => Promise<void> {
     const taskName = taskIdentifierToName(
@@ -68,8 +120,17 @@ export class AppConsumer<C> {
     };
   }
 
+  /**
+   * Read the already-computed result of a task.
+   *
+   * Returns a function which, when called with the task's arguments, looks up
+   * the value for that exact call.  This never schedules anything: if nobody
+   * has computed this call yet, it throws.
+   *
+   * @throws {NotFoundError} if no value has been stored for this call.
+   */
   public read<A extends unknown[], R>(
-    taskIdentifier: TaskIdentifier<C, A, R>,
+    taskIdentifier: TaskIdentifier<Env, A, R>,
   ): (...args: A) => Promise<R> {
     return async (...args: A) => {
       const taskName = taskIdentifierToName(
@@ -89,7 +150,27 @@ export class AppConsumer<C> {
   }
 }
 
-export class AppWorker<C> extends AppConsumer<C> {
+/**
+ * An {@link AppConsumer} which can also run tasks.
+ *
+ * Pass {@link AppWorker.handle} to a `Server` as its request handler and this
+ * process becomes a worker for the topics that server listens on.
+ */
+export class AppWorker<Env> extends AppConsumer<Env> {
+  /**
+   * Glue between this class and the underlying `Server.loop` handler.
+   *
+   * Looks the task up by name, invokes it through the codec with a fresh
+   * {@link ActiveWorker} to draw the environment from, and normalises the
+   * outcome into the `Response | Defer` the server expects.  A {@link Defer}
+   * thrown by {@link ActiveWorker.call} is a control-flow signal, not a
+   * failure, so it is returned rather than propagated; any other error is a
+   * genuine task failure and bubbles up.
+   *
+   * @throws {TaskNotFoundError} if this worker doesn't implement the requested
+   * task.  Every worker must be able to handle every job on its topic, so this
+   * means the fleet is misconfigured.
+   */
   public readonly handle = async (
     request: Request,
     connection: Connection,
@@ -114,17 +195,37 @@ export class AppWorker<C> extends AppConsumer<C> {
   };
 }
 
-export class ActiveWorker<C> {
+/**
+ * A task's handle onto the worker running it.
+ *
+ * This is how a task calls other tasks and waits for their results, using the
+ * defer-and-retry mechanism.  Codecs typically pass it straight through as the
+ * task's `Env`, but that is the codec's choice, not a requirement.
+ */
+export class ActiveWorker<Env> {
   private readonly connection: Connection;
-  private readonly registry: Registry<C>;
+  private readonly registry: Registry<Env>;
 
-  public constructor(connection: Connection, registry: Registry<C>) {
+  public constructor(connection: Connection, registry: Registry<Env>) {
     this.connection = connection;
     this.registry = registry;
   }
 
+  /**
+   * Directly call a brrr task from within another task.
+   *
+   * Do not call this unless you are, yourself, already inside a brrr task.
+   *
+   * Returns a function which resolves to the callee's result if it has already
+   * been computed.  If it hasn't, that function throws a {@link Defer} instead,
+   * which unwinds you out of your task; the worker then schedules the callee
+   * and re-runs your task from the top once the result exists.  This means your
+   * task body may run several times and must be idempotent.
+   *
+   * `topic` defaults to the topic the calling task is being served on.
+   */
   public call<A extends unknown[], R>(
-    taskIdentifier: TaskIdentifier<C, A, R>,
+    taskIdentifier: TaskIdentifier<Env, A, R>,
     topic?: string | undefined,
   ): (...args: A) => Promise<R> {
     const taskName = taskIdentifierToName(
@@ -141,6 +242,22 @@ export class ActiveWorker<C> {
     };
   }
 
+  /**
+   * Takes a number of task calls and awaits each of them.  If they've all been
+   * computed, returns their values; otherwise defers the ones that haven't
+   * been, all at once.
+   *
+   * This is the difference between fanning out and going one at a time: calling
+   * {@link ActiveWorker.call} sequentially defers on the first uncomputed
+   * callee, so each round trip only discovers one new call.  Gathering them
+   * collects every {@link Defer} raised across the batch into a single one, so
+   * the whole fan-out is scheduled in one go.
+   *
+   * Only errors of type {@link Defer} are absorbed this way; anything else a
+   * task throws propagates as usual.
+   */
+  // Type annotations are modeled after Promise.all: explicit types for 1-5
+  // arguments (and when all have the same type), and a catch-all for the rest.
   public async gather<T1>(t1: T1): Promise<[Awaited<T1>]>;
   public async gather<T1, T2>(
     t1: T1,

--- a/typescript/src/codec.test.ts
+++ b/typescript/src/codec.test.ts
@@ -3,9 +3,9 @@ import { deepStrictEqual, notDeepStrictEqual } from "node:assert/strict";
 import type { Codec } from "./codec.ts";
 import { ActiveWorker } from "./app.ts";
 
-export async function codecContractTest<C>(
-  codec: Codec<C>,
-  contextFactory: () => C,
+export async function codecContractTest<Env>(
+  codec: Codec<Env>,
+  envFactory: () => Env,
 ) {
   await suite("store-contract", async () => {
     const cases: Record<string, [unknown[], unknown[]]> = {
@@ -64,14 +64,14 @@ export async function codecContractTest<C>(
     await suite(
       "round trip: encodeCall -> invokeTask -> decodeReturn",
       async () => {
-        async function identify<T>(_: C, a: T): Promise<T> {
+        async function identify<T>(_: Env, a: T): Promise<T> {
           return a;
         }
 
         for (const [name, args] of Object.entries(cases)) {
           await test(name, async () => {
             const call = await codec.encodeCall(identify.name, [args[0]]);
-            const context = contextFactory();
+            const env = envFactory();
             const result = await codec.invokeTask(
               call,
               identify,
@@ -79,7 +79,7 @@ export async function codecContractTest<C>(
               () => null as ActiveWorker,
             );
             const decoded = await codec.decodeReturn(identify.name, result);
-            deepStrictEqual(decoded, await identify(context, args[1]));
+            deepStrictEqual(decoded, await identify(env, args[1]));
           });
         }
       },

--- a/typescript/src/codec.ts
+++ b/typescript/src/codec.ts
@@ -1,13 +1,13 @@
 import type { ActiveWorker, Task } from "./app.ts";
 import type { Call } from "./call.ts";
 
-export interface Codec<C> {
+export interface Codec<Env> {
   encodeCall<A extends unknown[]>(taskName: string, args: A): Promise<Call>;
 
   invokeTask<A extends unknown[], R>(
     call: Call,
-    task: Task<C, A, R>,
-    activeWorker: ActiveWorker<C>,
+    task: Task<Env, A, R>,
+    activeWorker: ActiveWorker<Env>,
   ): Promise<Uint8Array>;
 
   decodeReturn(taskName: string, payload: Uint8Array): unknown;

--- a/typescript/src/connection.ts
+++ b/typescript/src/connection.ts
@@ -6,11 +6,23 @@ import type { Publisher, Subscriber } from "./emitter.ts";
 import { BrrrShutdownSymbol, BrrrTaskDoneEventSymbol } from "./symbol.ts";
 import { PendingReturn, ScheduleMessage, TaggedTuple } from "./tagged-tuple.ts";
 
+/**
+ * A call which a handler wants scheduled before it can make progress.
+ */
 export interface DeferredCall {
+  /**
+   * The topic to schedule this call on.  Undefined means self: the topic the
+   * deferring handler itself is being served on.
+   */
   readonly topic: string | undefined;
   readonly call: Call;
 }
 
+/**
+ * When a task is called and hasn't been computed yet, the handler returns a
+ * Defer.  Workers see this and schedule the deferred calls to be computed,
+ * after which the deferring call is retried.
+ */
 export class Defer {
   public readonly calls: DeferredCall[];
 
@@ -19,23 +31,65 @@ export class Defer {
   }
 }
 
+/**
+ * A single unit of work handed to a request handler.
+ *
+ * Probably some extra useful out-of-band metadata at some point?  Something
+ * like "headers"?  Metadata?  For now we only have calls in a request, but it's
+ * very likely we'll want to add things here very soon and this is part of the
+ * public API, so let's wrap the call itself in a single-member Request type.
+ */
 export interface Request {
+  /** The actual semantically meaningful part of the call. */
   readonly call: Call;
 }
 
+/** The successful result of a handled request. */
 export interface Response {
   readonly payload: Uint8Array;
 }
 
+/**
+ * User-supplied task dispatcher.
+ *
+ * Returns a {@link Response} when the call could be computed, or a
+ * {@link Defer} listing the calls which must be computed first.
+ */
 export type RequestHandler = (
   request: Request,
   connection: Connection,
 ) => Promise<Response | Defer>;
 
+/**
+ * A connection in its most basic form, to call _out_ to brrr.
+ *
+ * You can read values, and you can asynchronously schedule jobs, but it doesn't
+ * allow "calling" jobs using the defer-and-retry mechanism.  That's done by
+ * active applications, see {@link Server}.
+ */
 export class Connection {
+  /**
+   * Non-critical, non-persistent information.  Still figuring out if it makes
+   * sense to have this dichotomy supported so explicitly at the top-level of
+   * the API.  We run the risk of somehow letting semantically important
+   * information seep into this cache, and suddenly it is effectively just part
+   * of memory again, at which point what's the split for?
+   */
   public readonly cache: Cache;
+
+  /** A storage backend for calls, values and pending returns. */
   public readonly memory: Memory;
+
+  /** Where jobs are published to be picked up by workers. */
   public readonly emitter: Publisher;
+
+  /**
+   * Maximum task executions per root job.  Hard-coded, not intended to be
+   * configurable or ever even be hit, for that matter.  If you hit this you
+   * almost certainly have a pathological workflow edge case causing massive
+   * reruns.  If you actually need to increase this because your flows genuinely
+   * hit this limit, I'm impressed.
+   */
   public readonly spawnLimit = 10_000;
 
   public constructor(store: Store, cache: Cache, emitter: Publisher) {
@@ -44,6 +98,23 @@ export class Connection {
     this.emitter = emitter;
   }
 
+  /**
+   * Publish a job onto a topic, subject to the spawn limit.
+   *
+   * Incredibly mother-of-all ad-hoc definitions.  Doesn't use the topic for
+   * counting spawn limits: the spawn limit is currently intended to never be
+   * hit at all: it's a _semantic_ check, not a _runtime_ check.  It's not
+   * intended for example to give paying customers a higher spawn limit than
+   * free ones.  It's intended to catch infinite recursion and non-idempotent
+   * call graphs.
+   *
+   * @throws {SpawnLimitError} when the root job has spawned too many tasks.
+   * Throwing here allows the user of brrr to decide how to handle this: what
+   * kind of logging?  Does the worker crash in order to flag the problem to the
+   * service orchestrator, relying on auto restarts to maintain uptime while
+   * allowing monitoring to go flag a bigger issue to admins?  Or just wrap it
+   * in a `while (true)` loop which catches and ignores specifically this error?
+   */
   public async putJob(topic: string, job: ScheduleMessage): Promise<void> {
     if ((await this.cache.incr(`brrr/count/${job.rootId}`)) > this.spawnLimit) {
       throw new SpawnLimitError(this.spawnLimit, job.rootId, job.callHash);
@@ -51,25 +122,63 @@ export class Connection {
     await this.emitter.emit(topic, TaggedTuple.encodeToString(job));
   }
 
+  /**
+   * Schedule this call on the brrr workforce.
+   *
+   * This method should be called for top-level workflow calls only.
+   */
   public async scheduleRaw(topic: string, call: Call): Promise<void> {
+    // Best effort optimization which is NOT semantically relevant.  It would in
+    // fact be a good test to disable this and verify all unit tests still pass
+    // (discrepancies in task call counts notwithstanding).
     if (await this.memory.hasValue(call.callHash)) {
       return;
     }
     await this.memory.setCall(call);
+    // Random root id for every call so we can disambiguate retries
     const rootId = randomUUID().replaceAll("-", "");
     await this.putJob(topic, new ScheduleMessage(rootId, call.callHash));
   }
 
+  /**
+   * Returns the value of a task, or undefined if it's not present in the store.
+   */
   public async readRaw(callHash: string): Promise<Uint8Array | undefined> {
     return this.memory.getValue(callHash);
   }
 }
 
+/**
+ * A connection which can also _serve_ jobs: pull them off a topic, hand them to
+ * a handler, store the result and kick off whoever was waiting for it.
+ *
+ * Separate class for now, might not need to be, although it does leave open the
+ * possibility of having different emitter protocols: consumer vs producer?
+ */
 export class Server extends Connection {
   public constructor(store: Store, cache: Cache, emitter: Publisher) {
     super(store, cache, emitter);
   }
 
+  /**
+   * Workers take jobs from the queue, one at a time, and handle them.  They
+   * have read and write access to the store, and are responsible for managing
+   * the output of tasks and scheduling new ones.
+   *
+   * `topic` is the topic on which this brrr instance is _listening_ for new
+   * jobs.  It can _call_ any jobs on any topic, but it expects to serve its
+   * jobs only on this specific one.
+   *
+   * Every worker MUST be able to handle any job which it pulls from the queue.
+   * A crucial operating principle of brrr is the lack of a central agent or
+   * scheduler.  Topics are how work is segregated, but within a topic every
+   * worker is equal and every worker must handle every job.  Rejecting a job
+   * will be considered a job failure by the queue [in any decent queue
+   * implementation, e.g. SQS dead lettering after a while].
+   *
+   * The loop runs until `getMessage` yields {@link BrrrShutdownSymbol}; an
+   * undefined message means "nothing right now, poll again".
+   */
   public async loop(
     topic: string,
     handler: RequestHandler,
@@ -90,6 +199,12 @@ export class Server extends Connection {
     }
   }
 
+  /**
+   * Handle a single encoded {@link ScheduleMessage} off the wire.
+   *
+   * Returns the handled call if it produced a value, or undefined if the
+   * handler deferred and the call still needs to be retried later.
+   */
   protected async handleMessage(
     requestHandler: RequestHandler,
     topic: string,
@@ -99,6 +214,12 @@ export class Server extends Connection {
     const call = await this.memory.getCall(message.callHash);
     const handled = await requestHandler({ call }, this);
     if (handled instanceof Defer) {
+      // Any of these calls could throw a SpawnLimitError: let that bubble up.
+      // This is very ugly but I want to keep the contract of throwing
+      // exceptions on spawn limits, even though it's _technically_ a user
+      // error.  It's a very nice failure mode and it allows the user to
+      // automatically lean on their fleet monitoring to measure the health of
+      // their workflows, and debugging this issue can otherwise be very hard.
       await Promise.all(
         handled.calls.map((child) => {
           return this.scheduleCallNested(topic, child, message);
@@ -106,7 +227,15 @@ export class Server extends Connection {
       );
       return;
     }
+    // This can end up in a race against another worker to write the value.
     await this.memory.setValue(message.callHash, handled.payload);
+    // Scheduling the returns one by one is ugly and it's tempting to reach for
+    // Promise.allSettled here.  However: I don't want to blanket catch all
+    // errors, only SpawnLimitError.  You'd need to do manual filtering of
+    // errors, check if there are any non-spawn-limit ones, if so throw those
+    // immediately, otherwise throw a spawn limit error once everything
+    // finishes.  It's about as convoluted as just doing it this way, without
+    // any of the clarity.
     let spawnLimitError: SpawnLimitError;
     await this.memory.withPendingReturnsRemove(
       message.callHash,
@@ -130,6 +259,9 @@ export class Server extends Connection {
     return call;
   }
 
+  /**
+   * Kick off a parent which was waiting for a now-completed call.
+   */
   private async scheduleReturnCall(
     pendingReturn: PendingReturn,
   ): Promise<void> {
@@ -140,11 +272,29 @@ export class Server extends Connection {
     await this.putJob(pendingReturn.topic, job);
   }
 
+  /**
+   * Schedule this call on the brrr workforce.
+   *
+   * This is the real internal entrypoint which should be used by all brrr
+   * internal-facing code, to avoid confusion about what's internal API and
+   * what's external.
+   *
+   * This method is for calls which are scheduled from within another brrr call.
+   * When the work scheduled by this call has completed, that worker must kick
+   * off the parent (which is the flow doing the calling of this function,
+   * "now").
+   *
+   * This will always kick off the call, it doesn't check if a return value
+   * already exists for this call.
+   */
   private async scheduleCallNested(
     topic: string,
     child: DeferredCall,
     parent: ScheduleMessage,
   ): Promise<void> {
+    // First the call because it is perennial, it just describes the actual call
+    // being made, it doesn't cause any further action and it's safe under all
+    // races.
     await this.memory.setCall(child.call);
     const callHash = child.call.callHash;
     const pendingReturn = new PendingReturn(
@@ -152,6 +302,12 @@ export class Server extends Connection {
       parent.callHash,
       topic,
     );
+    // Note this can be immediately read out by a racing return call.  The
+    // pathological case is: we are late to a party and another worker is
+    // actually just done handling this call, and just before it reads out the
+    // addresses to which to return, it is added here.  That's still OK because
+    // it will then immediately call this parent flow back, which is fine
+    // because the result does in fact exist.
     const shouldSchedule = await this.memory.addPendingReturns(
       callHash,
       pendingReturn,
@@ -163,6 +319,11 @@ export class Server extends Connection {
   }
 }
 
+/**
+ * A {@link Server} for emitters which push work to us instead of us polling for
+ * it: rather than running a {@link Server.loop}, you register a handler per
+ * topic and the emitter invokes it for every message.
+ */
 export class SubscriberServer extends Server {
   public override readonly emitter: Publisher & Subscriber;
 
@@ -175,6 +336,12 @@ export class SubscriberServer extends Server {
     this.emitter = emitter;
   }
 
+  /**
+   * Subscribe to a topic and handle every job published on it.
+   *
+   * The same rule as {@link Server.loop} applies: every worker must be able to
+   * handle every job on the topic it listens to.
+   */
   public listen(topic: string, handler: RequestHandler) {
     this.emitter.on(topic, async (callId: string): Promise<void> => {
       const result = await this.handleMessage(handler, topic, callId);

--- a/typescript/src/local-app.ts
+++ b/typescript/src/local-app.ts
@@ -1,7 +1,7 @@
 import { SubscriberServer } from "./connection.ts";
 import {
   AppWorker,
-  type NoContextTask,
+  type AsyncFn,
   type Handlers,
   type TaskIdentifier,
   taskIdentifierToName,
@@ -16,17 +16,17 @@ import {
 import { NotFoundError } from "./errors.ts";
 import { BrrrTaskDoneEventSymbol } from "./symbol.ts";
 
-export class LocalApp<C> {
+export class LocalApp<Env> {
   public readonly topic: string;
   public readonly server: SubscriberServer;
-  public readonly app: AppWorker<C>;
+  public readonly app: AppWorker<Env>;
 
   private hasRun = false;
 
   public constructor(
     topic: string,
     server: SubscriberServer,
-    app: AppWorker<C>,
+    app: AppWorker<Env>,
   ) {
     this.topic = topic;
     this.server = server;
@@ -35,13 +35,13 @@ export class LocalApp<C> {
 
   public schedule<A extends unknown[], R>(
     handler: Parameters<typeof this.app.schedule<A, R>>[0],
-  ): NoContextTask<A, void> {
+  ): AsyncFn<A, void> {
     return this.app.schedule(handler, this.topic);
   }
 
   public read<A extends unknown[], R>(
     ...args: Parameters<typeof this.app.read<A, R>>
-  ): NoContextTask<A, R> {
+  ): AsyncFn<A, R> {
     return this.app.read(...args);
   }
 
@@ -54,16 +54,18 @@ export class LocalApp<C> {
   }
 }
 
-export class LocalBrrr<C> {
+export class LocalBrrr<Env> {
   private readonly topic: string;
-  private readonly registry: Registry<C>;
+  private readonly registry: Registry<Env>;
 
-  public constructor(topic: string, registry: Registry<C>) {
+  public constructor(topic: string, registry: Registry<Env>) {
     this.topic = topic;
     this.registry = registry;
   }
 
-  public run<A extends unknown[], R>(taskIdentifier: TaskIdentifier<C, A, R>) {
+  public run<A extends unknown[], R>(
+    taskIdentifier: TaskIdentifier<Env, A, R>,
+  ) {
     const store = new InMemoryStore();
     const cache = new InMemoryCache();
     const emitter = new InMemoryEmitter();


### PR DESCRIPTION
Context -> Env
NoContextTask -> AsyncFn

left `DemoJsonCodecContext` alone as it is technically part of the public API.