### PR TITLE
feat: add metadata

### DIFF
--- a/brrr_demo.py
+++ b/brrr_demo.py
@@ -60,7 +60,12 @@ class DemoJsonKwargsCodec(Codec[DemoContext]):
         return Call(task_name=task_name, payload=payload, call_hash=call_hash)
 
     async def invoke_task(
-        self, call: Call, task, active_worker: ActiveWorker[DemoContext], signal: bytes
+        self,
+        call: Call,
+        task,
+        active_worker: ActiveWorker[DemoContext],
+        signal: bytes,
+        metadata: bytes,
     ) -> bytes:
         if signal == CANCEL_SIGNAL:
             raise Abandon()

--- a/brrr_demo.py
+++ b/brrr_demo.py
@@ -202,7 +202,9 @@ async def schedule_task(request: web.BaseRequest):
     if task_name not in brrr_app.get()._registry.handlers:
         return response(404, {"error": "No such task"})
 
-    root_id = await brrr_app.get().schedule(task_name, topic=topic_py)(**kwargs)
+    root_id = await brrr_app.get().schedule(task_name, topic=topic_py, metadata=b"")(
+        **kwargs
+    )
     return response(202, {"status": "accepted", "root_id": root_id})
 
 

--- a/python/src/brrr/app.py
+++ b/python/src/brrr/app.py
@@ -69,14 +69,14 @@ class AppConsumer[C]:
         task_spec: Task[C, P, R],
         *,
         topic: str,
-        metadata: bytes = b"",
+        metadata: bytes,
     ) -> Callable[P, Awaitable[str | None]]: ...
     @overload
     def schedule(
-        self, task_spec: str, *, topic: str, metadata: bytes = b""
+        self, task_spec: str, *, topic: str, metadata: bytes
     ) -> Callable[..., Awaitable[str | None]]: ...
     def schedule(
-        self, task_spec: Any, *, topic: str, metadata: bytes = b""
+        self, task_spec: Any, *, topic: str, metadata: bytes
     ) -> Callable[..., Awaitable[str | None]]:
         """Public-facing one-shot schedule method."""
         task_name = self._registry.handlers.spec2name(task_spec)

--- a/python/src/brrr/app.py
+++ b/python/src/brrr/app.py
@@ -69,13 +69,14 @@ class AppConsumer[C]:
         task_spec: Task[C, P, R],
         *,
         topic: str,
+        metadata: bytes = b"",
     ) -> Callable[P, Awaitable[str | None]]: ...
     @overload
     def schedule(
-        self, task_spec: str, *, topic: str
+        self, task_spec: str, *, topic: str, metadata: bytes = b""
     ) -> Callable[..., Awaitable[str | None]]: ...
     def schedule(
-        self, task_spec: Any, *, topic: str
+        self, task_spec: Any, *, topic: str, metadata: bytes = b""
     ) -> Callable[..., Awaitable[str | None]]:
         """Public-facing one-shot schedule method."""
         task_name = self._registry.handlers.spec2name(task_spec)
@@ -83,7 +84,7 @@ class AppConsumer[C]:
         async def f(*args: Any, **kwargs: Any) -> str | None:
             call = self._registry.codec.encode_call(task_name, args, kwargs)
             return await self._connection.schedule_raw(
-                topic, call.call_hash, task_name, call.payload
+                topic, call.call_hash, task_name, call.payload, metadata
             )
 
         return f
@@ -126,7 +127,8 @@ class AppWorker[C](AppConsumer[C]):
                 request.call,
                 handler,
                 ActiveWorker(conn, self._registry, RootId(request.root_id)),
-                signal,
+                signal=signal,
+                metadata=request.metadata,
             )
         except (Defer, Abandon) as e:
             return e
@@ -172,7 +174,8 @@ class ActiveWorker[C]:
             try:
                 payload = await self._connection._memory.get_value(call.call_hash)
             except NotFoundError:
-                raise Defer([DeferredCall(topic, call)])
+                # child metadata defaults to parent's unless codec reraises Defer with updated metadata
+                raise Defer([DeferredCall(topic, call, None)])
             else:
                 return self._registry.codec.decode_return(task_name, payload)
 

--- a/python/src/brrr/codec.py
+++ b/python/src/brrr/codec.py
@@ -35,7 +35,9 @@ class Codec[C](ABC):
         call: Call,
         task: Task[C, ..., Awaitable[Any]],
         active_worker: ActiveWorker[C],
+        *,
         signal: bytes,
+        metadata: bytes,
     ) -> bytes:
         raise NotImplementedError()
 

--- a/python/src/brrr/connection.py
+++ b/python/src/brrr/connection.py
@@ -166,7 +166,7 @@ class Connection:
         idempotency_key: str,
         task_name: str,
         payload: bytes,
-        metadata: bytes = b"",
+        metadata: bytes,
     ) -> str | None:
         """Schedule this call on the brrr workforce.
 
@@ -186,7 +186,7 @@ class Connection:
         job = ScheduleMessage(
             call_hash=idempotency_key,
             root_id=root_id,
-            metadata=metadata,
+            metadata=metadata.hex(),
         )
         await self._put_job(topic, job)
         return root_id
@@ -261,7 +261,9 @@ class Server(Connection):
         # because it will then immediately call this parent flow back, which is
         # fine because the result does in fact exist.
         child_topic = child.topic or my_topic
-        metadata = child.metadata if child.metadata is not None else parent.metadata
+        metadata: str = (
+            child.metadata.hex() if child.metadata is not None else parent.metadata
+        )
         call_hash = child.call.call_hash
         ret = PendingReturn(
             root_id=parent.root_id,
@@ -327,7 +329,9 @@ class Server(Connection):
         logger.debug(
             f"Calling {my_topic} -> {msg.root_id}/{msg.call_hash} -> {call.task_name}"
         )
-        req = Request(call=call, root_id=msg.root_id, metadata=msg.metadata)
+        req = Request(
+            call=call, root_id=msg.root_id, metadata=bytes.fromhex(msg.metadata)
+        )
         ret = await handler(req, self, signal)
         match ret:
             case Defer(calls=calls):

--- a/python/src/brrr/connection.py
+++ b/python/src/brrr/connection.py
@@ -70,8 +70,16 @@ class Request:
     # schedule operation.  Every “schedule” gets a new root id, regardless of
     # the call parameters, regardless of cache availability.
     root_id: str
-    # out-of-band metadata. Can store things like auth tokens or task depth limits
-    # here.
+    # Opaque out-of-band metadata: tracing context, task depth limits, anything
+    # non-semantic.  Comparable to SQS message attributes:
+    # https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-message-metadata.html
+    #
+    # Deliberately NOT part of the call hash, so it never participates in
+    # memoization: two calls differing only in metadata share a single cache
+    # entry.  A task must therefore not let metadata affect its return value.
+    #
+    # A task inherits its parent's metadata by default and can override what it
+    # passes to each child; it can never affect its parent's.
     metadata: bytes
 
 

--- a/python/src/brrr/connection.py
+++ b/python/src/brrr/connection.py
@@ -34,6 +34,8 @@ class DeferredCall:
     # None means self
     topic: str | None
     call: Call
+    # None means parent metadata
+    metadata: bytes | None
 
 
 class Defer(Exception):
@@ -68,11 +70,9 @@ class Request:
     # schedule operation.  Every “schedule” gets a new root id, regardless of
     # the call parameters, regardless of cache availability.
     root_id: str
-    # Probably some extra useful out-of-band metadata at some point?  Something
-    # like "headers"?  Metadata?  For now we only have calls in a request, but
-    # it’s very likely we’ll want to add things here very soon and this is part
-    # of the public API, so let’s wrap the call itself in a single-member
-    # Request class.
+    # out-of-band metadata. Can store things like auth tokens or task depth limits
+    # here.
+    metadata: bytes
 
 
 @dataclass
@@ -161,7 +161,12 @@ class Connection:
         await self._queue.put_message(topic, job.encode().decode("utf-8"))
 
     async def schedule_raw(
-        self, topic: str, idempotency_key: str, task_name: str, payload: bytes
+        self,
+        topic: str,
+        idempotency_key: str,
+        task_name: str,
+        payload: bytes,
+        metadata: bytes = b"",
     ) -> str | None:
         """Schedule this call on the brrr workforce.
 
@@ -181,6 +186,7 @@ class Connection:
         job = ScheduleMessage(
             call_hash=idempotency_key,
             root_id=root_id,
+            metadata=metadata,
         )
         await self._put_job(topic, job)
         return root_id
@@ -196,12 +202,6 @@ class Connection:
 
     async def set_signal(self, root_id: str, signal: bytes) -> None:
         await self._memory.set_signal(root_id, signal)
-
-    async def clear_signal(self, root_id: str) -> None:
-        try:
-            await self._memory.clear_signal(root_id)
-        except NotFoundError:
-            pass
 
 
 # Separate classes for now, might not need to be, although it does leave open
@@ -224,7 +224,9 @@ class Server(Connection):
         Server._total_workers += 1
 
     async def _schedule_return_call(self, ret: PendingReturn) -> None:
-        job = ScheduleMessage(root_id=ret.root_id, call_hash=ret.call_hash)
+        job = ScheduleMessage(
+            root_id=ret.root_id, call_hash=ret.call_hash, metadata=ret.metadata
+        )
         await self._put_job(ret.topic, job)
 
     async def _schedule_call_nested(
@@ -259,17 +261,20 @@ class Server(Connection):
         # because it will then immediately call this parent flow back, which is
         # fine because the result does in fact exist.
         child_topic = child.topic or my_topic
+        metadata = child.metadata if child.metadata is not None else parent.metadata
         call_hash = child.call.call_hash
         ret = PendingReturn(
             root_id=parent.root_id,
             call_hash=parent.call_hash,
             topic=my_topic,
+            metadata=parent.metadata,
         )
         should_schedule = await self._memory.add_pending_return(call_hash, ret)
         if should_schedule:
             job = ScheduleMessage(
                 call_hash=call_hash,
                 root_id=parent.root_id,
+                metadata=metadata,
             )
             await self._put_job(child_topic, job)
 
@@ -322,7 +327,7 @@ class Server(Connection):
         logger.debug(
             f"Calling {my_topic} -> {msg.root_id}/{msg.call_hash} -> {call.task_name}"
         )
-        req = Request(call=call, root_id=msg.root_id)
+        req = Request(call=call, root_id=msg.root_id, metadata=msg.metadata)
         ret = await handler(req, self, signal)
         match ret:
             case Defer(calls=calls):

--- a/python/src/brrr/demo_pickle_codec.py
+++ b/python/src/brrr/demo_pickle_codec.py
@@ -41,7 +41,9 @@ class DemoPickleCodec(Codec[DemoPickleCodecContext]):
         call: Call,
         task: Task[DemoPickleCodecContext, ..., Any],
         active_worker: ActiveWorker[DemoPickleCodecContext],
+        *,
         signal: bytes,
+        metadata: bytes = b"",
     ) -> bytes:
         args, kwargs = pickle.loads(call.payload)
         return pickle.dumps(await task(active_worker, *args, **kwargs))

--- a/python/src/brrr/local_app.py
+++ b/python/src/brrr/local_app.py
@@ -85,7 +85,7 @@ class LocalBrrr[C]:
             async with local_app(
                 topic=self.topic, handlers=self.handlers, codec=self.codec
             ) as app:
-                await app.schedule(f)(*args, **kwargs)
+                await app.schedule(f, metadata=b"")(*args, **kwargs)
                 await app.run()
                 return await app.read(f)(*args, **kwargs)
 

--- a/python/src/brrr/tagged_tuple.py
+++ b/python/src/brrr/tagged_tuple.py
@@ -32,33 +32,13 @@ class TaggedTuple:
     tag: ClassVar[int]
 
     def astuple(self) -> tuple[Any, ...]:
-        # raw bytes possibly could have non utf8 so convert to hex representation
-        def enc(field: dataclasses.Field[Any], val: Any) -> Any:
-            if field.type is bytes:
-                return val.hex()
-            return val
-
-        return (self.tag,) + tuple(
-            enc(field, getattr(self, field.name)) for field in dataclasses.fields(self)
-        )
+        return (self.tag,) + dataclasses.astuple(self)
 
     @classmethod
     def fromtuple(cls, t: tuple[Any, ...]) -> Self:
         if t[0] != cls.tag:
             raise ValueError(f"{cls.__name__} decode tag mismatch: {t[0]} != {cls.tag}")
-        if len(t) - 1 != len(dataclasses.fields(cls)):
-            raise ValueError(
-                f"{cls.__name__} incorrect number of fields: {len(dataclasses.fields(cls))} vs {len(t) - 1}"
-            )
-
-        def dec(field: dataclasses.Field[Any], val: Any) -> Any:
-            if field.type is not bytes:
-                return val
-            return bytes.fromhex(val)
-
-        return cls(
-            *(dec(field, val) for field, val in zip(dataclasses.fields(cls), t[1:]))
-        )
+        return cls(*t[1:])
 
 
 @dataclass(frozen=True)
@@ -78,7 +58,7 @@ class PendingReturn(TaggedTuple):
     root_id: str
     call_hash: str
     topic: str
-    metadata: bytes
+    metadata: str
 
 
 @dataclass(frozen=True)
@@ -86,4 +66,4 @@ class ScheduleMessage(TaggedTupleStrings):
     tag = 4
     root_id: str
     call_hash: str
-    metadata: bytes
+    metadata: str

--- a/python/src/brrr/tagged_tuple.py
+++ b/python/src/brrr/tagged_tuple.py
@@ -32,13 +32,33 @@ class TaggedTuple:
     tag: ClassVar[int]
 
     def astuple(self) -> tuple[Any, ...]:
-        return (self.tag,) + dataclasses.astuple(self)
+        # raw bytes possibly could have non utf8 so convert to hex representation
+        def enc(field: dataclasses.Field[Any], val: Any) -> Any:
+            if field.type is bytes:
+                return val.hex()
+            return val
+
+        return (self.tag,) + tuple(
+            enc(field, getattr(self, field.name)) for field in dataclasses.fields(self)
+        )
 
     @classmethod
     def fromtuple(cls, t: tuple[Any, ...]) -> Self:
         if t[0] != cls.tag:
             raise ValueError(f"{cls.__name__} decode tag mismatch: {t[0]} != {cls.tag}")
-        return cls(*t[1:])
+        if len(t) - 1 != len(dataclasses.fields(cls)):
+            raise ValueError(
+                f"{cls.__name__} incorrect number of fields: {len(dataclasses.fields(cls))} vs {len(t) - 1}"
+            )
+
+        def dec(field: dataclasses.Field[Any], val: Any) -> Any:
+            if field.type is not bytes:
+                return val
+            return bytes.fromhex(val)
+
+        return cls(
+            *(dec(field, val) for field, val in zip(dataclasses.fields(cls), t[1:]))
+        )
 
 
 @dataclass(frozen=True)
@@ -54,14 +74,16 @@ class TaggedTupleStrings(TaggedTuple):
 
 @dataclass(frozen=True)
 class PendingReturn(TaggedTuple):
-    tag = 1
+    tag = 3
     root_id: str
     call_hash: str
     topic: str
+    metadata: bytes
 
 
 @dataclass(frozen=True)
 class ScheduleMessage(TaggedTupleStrings):
-    tag = 2
+    tag = 4
     root_id: str
     call_hash: str
+    metadata: bytes

--- a/python/tests/contract_store.py
+++ b/python/tests/contract_store.py
@@ -288,9 +288,7 @@ class MemoryContract(ByteStoreContract):
 
             call_hash = "key"
             one = PendingReturn(
-                root_id="root",
-                call_hash="parent",
-                topic=topic,
+                root_id="root", call_hash="parent", topic=topic, metadata=b""
             )
 
             # base case

--- a/python/tests/contract_store.py
+++ b/python/tests/contract_store.py
@@ -288,7 +288,7 @@ class MemoryContract(ByteStoreContract):
 
             call_hash = "key"
             one = PendingReturn(
-                root_id="root", call_hash="parent", topic=topic, metadata=b""
+                root_id="root", call_hash="parent", topic=topic, metadata=""
             )
 
             # base case

--- a/python/tests/test_app.py
+++ b/python/tests/test_app.py
@@ -57,7 +57,7 @@ async def test_app_worker(topic: str, task_name: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        root_id = await app.schedule(foo, topic=topic)(122)
+        root_id = await app.schedule(foo, topic=topic, metadata=b"")(122)
         assert root_id is not None
         await conn.loop(topic, app.handle)
         assert await app.read(foo)(122) == 457
@@ -81,12 +81,12 @@ async def test_app_worker_no_reschedule_cached(topic: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        root_id = await app.schedule(foo, topic=topic)(4)
+        root_id = await app.schedule(foo, topic=topic, metadata=b"")(4)
         assert root_id is not None
         await conn.loop(topic, app.handle)
         assert await app.read(foo)(4) == 16
 
-        empty_root_id = await app.schedule(foo, topic=topic)(4)
+        empty_root_id = await app.schedule(foo, topic=topic, metadata=b"")(4)
         assert empty_root_id is None
         await conn.loop(topic, app.handle)
         assert len(calls) == 1
@@ -111,8 +111,8 @@ async def test_app_worker_abandon(topic: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(fib, topic=topic)(4)
-        await app.schedule(fib, topic=topic)(-4)
+        await app.schedule(fib, topic=topic, metadata=b"")(4)
+        await app.schedule(fib, topic=topic, metadata=b"")(-4)
         await conn.loop(topic, app.handle)
         assert await app.read(fib)(4) == 3
         with pytest.raises(NotFoundError):
@@ -131,7 +131,7 @@ async def test_app_consumer(topic: str, task_name: str) -> None:
         appw = AppWorker(
             handlers={task_name: foo}, codec=DemoPickleCodec(), connection=conn
         )
-        await appw.schedule(foo, topic=topic)(5)
+        await appw.schedule(foo, topic=topic, metadata=b"")(5)
         await conn.loop(topic, appw.handle)
 
     # Now test that a read-only app can read that
@@ -304,7 +304,7 @@ async def test_exc_gather(topic: str, task_name: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(foo, topic=topic)()
+        await app.schedule(foo, topic=topic, metadata=b"")()
         await conn.loop(topic, app.handle)
         assert await app.read(foo)() == 1234
 
@@ -332,7 +332,7 @@ async def test_topics_separate_app_same_conn(topic: str, task_name: str) -> None
         app2 = AppWorker(
             handlers={name_two: two}, codec=DemoPickleCodec(), connection=conn
         )
-        await app2.schedule(name_two, topic=t2)(7)
+        await app2.schedule(name_two, topic=t2, metadata=b"")(7)
         await asyncio.gather(conn.loop(t1, app1.handle), conn.loop(t2, app2.handle))
 
 
@@ -357,7 +357,7 @@ async def test_topics_separate_app_separate_conn(topic: str, task_name: str) -> 
             app2 = AppWorker(
                 handlers={name_two: two}, codec=DemoPickleCodec(), connection=conn2
             )
-            await app2.schedule(name_two, topic=t2)(7)
+            await app2.schedule(name_two, topic=t2, metadata=b"")(7)
             await asyncio.gather(
                 conn1.loop(t1, app1.handle), conn2.loop(t2, app2.handle)
             )
@@ -383,7 +383,7 @@ async def test_topics_same_app(topic: str, task_name: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(name_two, topic=t2)(7)
+        await app.schedule(name_two, topic=t2, metadata=b"")(7)
         # Listen on different topics with the same worker.
         await asyncio.gather(conn.loop(t1, app.handle), conn.loop(t2, app.handle))
 
@@ -399,7 +399,7 @@ async def test_weird_names(topic: str, task_name: str) -> None:
         app = AppWorker(
             handlers={task_name: double}, codec=DemoPickleCodec(), connection=conn
         )
-        await app.schedule(task_name, topic=topic)(7)
+        await app.schedule(task_name, topic=topic, metadata=b"")(7)
         await conn.loop(topic, app.handle)
         assert await app.read(task_name)(7) == 14
 
@@ -434,7 +434,7 @@ async def test_stop_when_empty(topic: str, task_name: str) -> None:
         app = AppWorker(
             handlers={task_name: foo}, codec=DemoPickleCodec(), connection=conn
         )
-        await app.schedule(foo, topic=topic)(3)
+        await app.schedule(foo, topic=topic, metadata=b"")(3)
         await conn.loop(topic, app.handle)
 
     assert calls_pre == Counter({0: 1, 1: 2, 2: 2, 3: 2})
@@ -474,7 +474,7 @@ async def test_parallel(topic: str, task_name: str, use_gather: bool) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(top, topic=topic)()
+        await app.schedule(top, topic=topic, metadata=b"")()
         await asyncio.gather(*(conn.loop(topic, app.handle) for _ in range(parallel)))
 
 
@@ -507,7 +507,7 @@ async def test_stress_parallel(topic: str, task_name: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(top, topic=topic)()
+        await app.schedule(top, topic=topic, metadata=b"")()
 
         await asyncio.gather(*(conn.loop(topic, app.handle) for _ in range(10)))
 
@@ -565,7 +565,7 @@ async def test_no_debounce_parent(topic: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(parent, topic=topic)(50)
+        await app.schedule(parent, topic=topic, metadata=b"")(50)
         await asyncio.gather(
             *(conn.loop(topic, app.handle) for _ in range(num_workers))
         )
@@ -599,7 +599,7 @@ async def test_app_loop_resumable(topic: str) -> None:
         )
         while True:
             try:
-                await app.schedule(foo, topic=topic)(3)
+                await app.schedule(foo, topic=topic, metadata=b"")(3)
                 await conn.loop(topic, app.handle)
                 break
             except MyError:
@@ -637,7 +637,7 @@ async def test_app_loop_resumable_nested(topic: str, task_name: str) -> None:
         )
         while True:
             try:
-                await app.schedule(foo, topic=topic)(3)
+                await app.schedule(foo, topic=topic, metadata=b"")(3)
                 await conn.loop(topic, app.handle)
                 break
             except MyError:
@@ -663,7 +663,7 @@ async def test_app_handler_names(topic: str, task_name: str) -> None:
     async with local_app(
         topic=topic, handlers=handlers, codec=DemoPickleCodec()
     ) as app:
-        await app.schedule(name_bar)(4)
+        await app.schedule(name_bar, metadata=b"")(4)
         await app.run()
         assert await app.read(name_foo)(4) == 16
         assert await app.read(foo)(4) == 16
@@ -704,7 +704,7 @@ async def test_app_subclass(topic: str) -> None:
     handlers = dict(foo=foo, bar=bar, baz=baz)
     async with brrr.serve(queue, store, store) as conn:
         app = MyAppWorker(handlers=handlers, codec=DemoPickleCodec(), connection=conn)
-        await app.schedule(foo, topic=topic)(4)
+        await app.schedule(foo, topic=topic, metadata=b"")(4)
         await conn.loop(topic, app.handle)
         assert await app.read(foo)(4) == 14
 
@@ -749,8 +749,8 @@ async def test_custom_context(topic: str) -> None:
             codec=MyCodec(),
             connection=conn,
         )
-        await app.schedule(foo, topic=topic)()
-        await app.schedule(bar, topic=topic)()
+        await app.schedule(foo, topic=topic, metadata=b"")()
+        await app.schedule(bar, topic=topic, metadata=b"")()
         await conn.loop(topic, app.handle)
         assert await app.read(foo)() == "foo"
         assert await app.read(bar)() == "bar"
@@ -769,7 +769,7 @@ async def test_app_root_id(topic: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(foo, topic=topic)()
+        await app.schedule(foo, topic=topic, metadata=b"")()
         await conn.loop(topic, app.handle)
         # Ensure that it exists at all
         assert await app.read(foo)()
@@ -821,7 +821,7 @@ async def test_cancel_task(topic: str, task_name: str) -> None:
             codec=CancelCodec(),
             connection=conn,
         )
-        root_id = await app.schedule(foo_and_bar, topic=topic)(3)
+        root_id = await app.schedule(foo_and_bar, topic=topic, metadata=b"")(3)
         assert root_id is not None
         await conn.set_signal(root_id, CANCEL_SIGNAL)
         await conn.loop(topic, app.handle)
@@ -872,7 +872,7 @@ async def test_no_overwrite_return() -> None:
                 codec=DemoPickleCodec(),
                 connection=conn,
             )
-            await app.schedule(foo, topic=topic)()
+            await app.schedule(foo, topic=topic, metadata=b"")()
             await asyncio.gather(
                 conn.loop(topic, app.handle), conn.loop(topic, app.handle)
             )

--- a/python/tests/test_app.py
+++ b/python/tests/test_app.py
@@ -723,9 +723,15 @@ async def test_custom_context(topic: str) -> None:
             return Call(task_name=task_name, payload=b"", call_hash=task_name)
 
         async def invoke_task(
-            self, call: Call, handler: Any, active_worker: Any, signal: bytes
+            self,
+            call: Call,
+            task: Any,
+            active_worker: Any,
+            *,
+            signal: bytes,
+            metadata: bytes = b"",
         ) -> bytes:
-            result: str = await handler(call.task_name)
+            result: str = await task(call.task_name)
             return result.encode("utf-8")
 
         def decode_return(self, task_name: str, payload: bytes) -> Any:
@@ -781,11 +787,15 @@ async def test_cancel_task(topic: str, task_name: str) -> None:
             call: Call,
             task: Task[DemoPickleCodecContext, ..., Any],
             active_worker: ActiveWorker[DemoPickleCodecContext],
+            *,
             signal: bytes,
+            metadata: bytes = b"",
         ) -> bytes:
             if signal == CANCEL_SIGNAL:
                 raise Abandon
-            return await super().invoke_task(call, task, active_worker, signal)
+            return await super().invoke_task(
+                call, task, active_worker, signal=signal, metadata=metadata
+            )
 
     name_foo_and_bar, name_foo, name_bar = names(
         task_name, ("foo_and_bar", "foo", "bar")
@@ -867,3 +877,63 @@ async def test_no_overwrite_return() -> None:
                 conn.loop(topic, app.handle), conn.loop(topic, app.handle)
             )
             assert await app.read(foo)() == "first"
+
+
+async def test_app_depth_limit_using_metadata(topic: str) -> None:
+    store = InMemoryByteStore()
+    queue = CloseOnEmptyQueue([topic])
+    DEPTH_LIMIT = 10
+
+    class MyCodec(DemoPickleCodec):
+        async def invoke_task(
+            self,
+            call: Call,
+            task: Task[DemoPickleCodecContext, ..., Any],
+            active_worker: ActiveWorker[DemoPickleCodecContext],
+            signal: bytes,
+            metadata: bytes = b"",
+        ) -> bytes:
+            depth = int(metadata)
+            if depth > DEPTH_LIMIT:
+                raise Abandon
+            try:
+                return await super().invoke_task(
+                    call, task, active_worker, signal=signal, metadata=metadata
+                )
+            except Defer as e:
+                raise Defer(
+                    DeferredCall(
+                        call=dcall.call,
+                        topic=dcall.topic,
+                        metadata=str(depth + 1).encode(),
+                    )
+                    for dcall in e.calls
+                )
+
+    n = 0
+
+    async def foo(app: TestContext, a: int) -> int:
+        nonlocal n
+        n += 1
+        if a == 0:
+            # Prevent false positives from this test by exiting cleanly at some point
+            return 0
+        return await app.call(foo)(a - 1)
+
+    async with brrr.serve(queue, store, store) as conn:
+        app = AppWorker(
+            handlers={"foo": foo},
+            codec=MyCodec(),
+            connection=conn,
+        )
+        # times two to make sure it reaches depth before it overlaps with the second call
+        await app.schedule(foo, topic=topic, metadata=b"1")(2 * DEPTH_LIMIT)
+        await app.schedule(foo, topic=topic, metadata=b"1")(DEPTH_LIMIT - 1)
+
+        await conn.loop(topic, app.handle)
+
+        with pytest.raises(NotFoundError):
+            await app.read(foo)(2 * DEPTH_LIMIT)
+        await app.read(foo)(DEPTH_LIMIT - 1)
+
+        assert n == DEPTH_LIMIT * 2 + DEPTH_LIMIT - 1

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -33,6 +33,7 @@ async def test_conn_raw() -> None:
                                     task_name="inner",
                                     payload=b"inner call payload",
                                 ),
+                                metadata=b"",
                             ),
                         ]
                     )
@@ -129,6 +130,7 @@ async def test_conn_abandon() -> None:
                             task_name=child_task_name,
                             payload=b"payload",
                         ),
+                        metadata=None,
                     ),
                 ]
             )

--- a/python/tests/test_connection.py
+++ b/python/tests/test_connection.py
@@ -42,7 +42,7 @@ async def test_conn_raw() -> None:
         assert False, f"Unknown task name: {call.task_name}"
 
     async with brrr.serve(queue, store, store) as conn:
-        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123")
+        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123", metadata=b"")
         await conn.loop(TOPIC, handler)
         assert await conn.read_raw("hash1") == b"zim"
         assert await conn.read_raw("hash2") == b"inner return value"
@@ -69,8 +69,8 @@ async def test_conn_exception() -> None:
         return Response(payload=b"Good")
 
     async with brrr.serve(queue, store, store) as conn:
-        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123")
-        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123")
+        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123", metadata=b"")
+        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123", metadata=b"")
         with pytest.raises(MyError):
             await conn.loop(TOPIC, handler)
         assert await conn.read_raw("hash1") is None
@@ -87,7 +87,7 @@ async def test_conn_root_id() -> None:
         return Response(payload=request.root_id.encode("utf-8"))
 
     async with brrr.serve(queue, store, store) as conn:
-        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123")
+        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123", metadata=b"")
         await conn.loop(TOPIC, handler)
         # Just ensure that it exists at all
         assert await conn.read_raw("hash1")
@@ -147,6 +147,6 @@ async def test_conn_abandon() -> None:
                 return Abandon()
 
     async with brrr.serve(queue, store, store) as conn:
-        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123")
+        await conn.schedule_raw(TOPIC, "hash1", "foo", b"123", metadata=b"")
         await conn.loop(TOPIC, handler)
         assert await conn.read_raw("hash1") is None

--- a/python/tests/test_spawn_limit.py
+++ b/python/tests/test_spawn_limit.py
@@ -29,7 +29,7 @@ async def test_spawn_limit_depth(topic: str, task_name: str) -> None:
         app = AppWorker(
             handlers={task_name: foo}, codec=DemoPickleCodec(), connection=conn
         )
-        await app.schedule(task_name, topic=topic)(conn._spawn_limit + 3)
+        await app.schedule(task_name, topic=topic, metadata=b"")(conn._spawn_limit + 3)
 
         with pytest.raises(SpawnLimitError):
             await conn.loop(topic, app.handle)
@@ -59,7 +59,7 @@ async def test_spawn_limit_breadth_mapped(topic: str, task_name: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(name_foo, topic=topic)(conn._spawn_limit + 4)
+        await app.schedule(name_foo, topic=topic, metadata=b"")(conn._spawn_limit + 4)
 
         with pytest.raises(SpawnLimitError):
             await conn.loop(topic, app.handle)
@@ -94,7 +94,7 @@ async def test_spawn_limit_recoverable(topic: str, task_name: str) -> None:
             # Very ugly but this works for testing
             cache.inner = {}
             try:
-                await app.schedule(name_foo, topic=topic)(n)
+                await app.schedule(name_foo, topic=topic, metadata=b"")(n)
                 await conn.loop(topic, app.handle)
                 break
             except SpawnLimitError:
@@ -131,7 +131,7 @@ async def test_spawn_limit_breadth_manual(topic: str, task_name: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(name_foo, topic=topic)(conn._spawn_limit + 3)
+        await app.schedule(name_foo, topic=topic, metadata=b"")(conn._spawn_limit + 3)
         with pytest.raises(SpawnLimitError):
             await conn.loop(topic, app.handle)
 
@@ -165,7 +165,7 @@ async def test_spawn_limit_cached(topic: str, task_name: str) -> None:
             codec=DemoPickleCodec(),
             connection=conn,
         )
-        await app.schedule(name_foo, topic=topic)(conn._spawn_limit + 5)
+        await app.schedule(name_foo, topic=topic, metadata=b"")(conn._spawn_limit + 5)
         await conn.loop(topic, app.handle)
 
         assert n == 1

--- a/python/tests/test_store_base.py
+++ b/python/tests/test_store_base.py
@@ -65,7 +65,7 @@ async def test_memory_cas() -> None:
 )
 async def test_encode_decode_mixed_cases(scheduled_at: int, returns: set[str]) -> None:
     def make_pr(tag: str) -> PendingReturn:
-        return PendingReturn(root_id=tag, call_hash=tag, topic=tag)
+        return PendingReturn(root_id=tag, call_hash=tag, topic=tag, metadata=b"")
 
     pending_returns = PendingReturns(
         scheduled_at=scheduled_at, returns=set(map(make_pr, returns))

--- a/python/tests/test_store_base.py
+++ b/python/tests/test_store_base.py
@@ -65,7 +65,7 @@ async def test_memory_cas() -> None:
 )
 async def test_encode_decode_mixed_cases(scheduled_at: int, returns: set[str]) -> None:
     def make_pr(tag: str) -> PendingReturn:
-        return PendingReturn(root_id=tag, call_hash=tag, topic=tag, metadata=b"")
+        return PendingReturn(root_id=tag, call_hash=tag, topic=tag, metadata="")
 
     pending_returns = PendingReturns(
         scheduled_at=scheduled_at, returns=set(map(make_pr, returns))

--- a/typescript/demo/cli.ts
+++ b/typescript/demo/cli.ts
@@ -86,16 +86,29 @@ const CANCEL_SIGNAL = new TextEncoder().encode("CANCEL");
  * stops this call without writing a value or waking its parent.
  */
 class CancelJsonCodec extends DemoJsonCodec {
-  public override async invokeTask<A extends unknown[], R>(
-    call: Call,
-    handler: Task<DemoJsonCodecContext, A, R>,
-    activeWorker: DemoJsonCodecContext,
-    signal: Uint8Array,
-  ): Promise<Uint8Array> {
+  public override async invokeTask<A extends unknown[], R>({
+    call,
+    task,
+    activeWorker,
+    signal,
+    metadata,
+  }: {
+    call: Call;
+    task: Task<DemoJsonCodecContext, A, R>;
+    activeWorker: DemoJsonCodecContext;
+    signal: Uint8Array;
+    metadata: Uint8Array;
+  }): Promise<Uint8Array> {
     if (Buffer.compare(signal, CANCEL_SIGNAL) === 0) {
       throw new Abandon();
     }
-    return await super.invokeTask(call, handler, activeWorker, signal);
+    return await super.invokeTask({
+      call,
+      task,
+      activeWorker,
+      signal,
+      metadata,
+    });
   }
 }
 

--- a/typescript/src/app.test.ts
+++ b/typescript/src/app.test.ts
@@ -553,6 +553,79 @@ await matrixSuite(import.meta.filename, async (_, matrix) => {
       strictEqual(await app.read(foo)(4), 14);
     });
 
+    await test("depth limit using metadata", async () => {
+      const DEPTH_LIMIT = 10;
+
+      // Metadata is opaque to brrr, so a codec is free to use it as a depth
+      // counter: read the parent's depth on the way in, hand the incremented
+      // value to every child it defers to.
+      class MyCodec extends DemoJsonCodec {
+        public override async invokeTask<A extends unknown[], R>({
+          call,
+          task,
+          activeWorker,
+          signal,
+          metadata,
+        }: {
+          call: Call;
+          task: Task<DemoJsonCodecContext, A, R>;
+          activeWorker: DemoJsonCodecContext;
+          signal: Uint8Array;
+          metadata: Uint8Array;
+        }): Promise<Uint8Array> {
+          const depth = Number(decoder.decode(metadata));
+          if (depth > DEPTH_LIMIT) {
+            throw new Abandon();
+          }
+          try {
+            return await super.invokeTask({
+              call,
+              task,
+              activeWorker,
+              signal,
+              metadata,
+            });
+          } catch (err) {
+            if (!(err instanceof Defer)) {
+              throw err;
+            }
+            throw new Defer(
+              ...err.calls.map((dcall) => ({
+                topic: dcall.topic,
+                call: dcall.call,
+                metadata: encoder.encode(String(depth + 1)),
+              })),
+            );
+          }
+        }
+      }
+
+      let n = 0;
+
+      async function foo(app: TestContext, a: number): Promise<number> {
+        n++;
+        if (a === 0) {
+          // Prevent false positives from this test by exiting cleanly at some point
+          return 0;
+        }
+        return await app.call(foo)(a - 1);
+      }
+
+      const server = new Server(store, cache, publisher);
+      const app = new AppWorker(new MyCodec(), server, { foo });
+
+      // times two to make sure it reaches depth before it overlaps with the second call
+      await app.schedule(foo, topic, encoder.encode("1"))(2 * DEPTH_LIMIT);
+      await app.schedule(foo, topic, encoder.encode("1"))(DEPTH_LIMIT - 1);
+
+      await server.loop(topic, app.handle, flusher);
+
+      await rejects(app.read(foo)(2 * DEPTH_LIMIT), NotFoundError);
+      strictEqual(await app.read(foo)(DEPTH_LIMIT - 1), 0);
+
+      strictEqual(n, DEPTH_LIMIT * 2 + DEPTH_LIMIT - 1);
+    });
+
     await suite("spawn limit", async () => {
       await test("spawn limit depth", async () => {
         let n = 0;
@@ -725,13 +798,21 @@ await matrixSuite(import.meta.filename, async (_, matrix) => {
           return { taskName, payload: new Uint8Array(), callHash: taskName };
         }
 
-        public async invokeTask<A extends unknown[], R>(
-          call: Call,
-          handler: Task<string, A, R>,
-          _activeWorker: ActiveWorker<string>,
-        ): Promise<Uint8Array> {
+        public async invokeTask<A extends unknown[], R>({
+          call,
+          task,
+          activeWorker,
+          signal,
+          metadata,
+        }: {
+          call: Call;
+          task: Task<string, A, R>;
+          activeWorker: ActiveWorker<string>;
+          signal: Uint8Array;
+          metadata: Uint8Array;
+        }): Promise<Uint8Array> {
           // @ts-expect-error type cheat for test.
-          const result: string = await handler(call.taskName);
+          const result: string = await task(call.taskName);
           return encoder.encode(result);
         }
       }
@@ -770,14 +851,27 @@ await matrixSuite(import.meta.filename, async (_, matrix) => {
     const SIGINT = Uint8Array.of(0xf0, 0x9f, 0x9b, 0x91);
 
     class CancelCodec extends DemoJsonCodec {
-      override async invokeTask<A extends unknown[], R>(
-        call: Call,
-        handler: Task<DemoJsonCodecContext, A, R>,
-        activeWorker: DemoJsonCodecContext,
-        signal: Uint8Array,
-      ) {
+      override async invokeTask<A extends unknown[], R>({
+        call,
+        task,
+        activeWorker,
+        signal,
+        metadata,
+      }: {
+        call: Call;
+        task: Task<DemoJsonCodecContext, A, R>;
+        activeWorker: DemoJsonCodecContext;
+        signal: Uint8Array;
+        metadata: Uint8Array;
+      }) {
         if (Buffer.compare(signal, SIGINT) === 0) throw new Abandon();
-        return await super.invokeTask(call, handler, activeWorker, signal);
+        return await super.invokeTask({
+          call,
+          task,
+          activeWorker,
+          signal,
+          metadata,
+        });
       }
     }
 

--- a/typescript/src/app.ts
+++ b/typescript/src/app.ts
@@ -58,6 +58,7 @@ export class AppConsumer<C> {
   public schedule<A extends unknown[], R>(
     taskIdentifier: TaskIdentifier<C, A, R>,
     topic: string,
+    metadata: Uint8Array = Uint8Array.of(),
   ): (...args: A) => Promise<string | undefined> {
     const taskName = taskIdentifierToName(
       taskIdentifier,
@@ -65,7 +66,7 @@ export class AppConsumer<C> {
     );
     return async (...args: A): Promise<string | undefined> => {
       const call = await this.registry.codec.encodeCall(taskName, args);
-      return await this.connection.scheduleRaw(topic, call);
+      return await this.connection.scheduleRaw(topic, call, metadata);
     };
   }
 
@@ -114,12 +115,13 @@ export class AppWorker<C> extends AppConsumer<C> {
       throw new TaskNotFoundError(request.call.taskName);
     }
     try {
-      const payload = await this.registry.codec.invokeTask(
-        request.call,
-        handler,
-        new ActiveWorker(connection, this.registry),
+      const payload = await this.registry.codec.invokeTask({
+        call: request.call,
+        task: handler,
+        activeWorker: new ActiveWorker(connection, this.registry),
         signal,
-      );
+        metadata: request.metadata,
+      });
       return { payload };
     } catch (err) {
       if (err instanceof Defer || err instanceof Abandon) {
@@ -151,7 +153,7 @@ export class ActiveWorker<C> {
       const call = await this.registry.codec.encodeCall(taskName, args);
       const payload = await this.connection.memory.getValue(call.callHash);
       if (!payload) {
-        throw new Defer({ topic, call });
+        throw new Defer({ topic, call, metadata: undefined });
       }
       return this.registry.codec.decodeReturn(taskName, payload) as R;
     };

--- a/typescript/src/codec.test.ts
+++ b/typescript/src/codec.test.ts
@@ -72,13 +72,14 @@ export async function codecContractTest<C>(
           await test(name, async () => {
             const call = await codec.encodeCall(identify.name, [args[0]]);
             const context = contextFactory();
-            const result = await codec.invokeTask(
+            const result = await codec.invokeTask({
               call,
-              identify,
+              task: identify,
               // @ts-expect-error type cheat for test
-              () => null as ActiveWorker,
-              new Uint8Array(),
-            );
+              activeWorker: () => null as ActiveWorker,
+              signal: new Uint8Array(),
+              metadata: new Uint8Array(),
+            });
             const decoded = await codec.decodeReturn(identify.name, result);
             deepStrictEqual(decoded, await identify(context, args[1]));
           });

--- a/typescript/src/codec.ts
+++ b/typescript/src/codec.ts
@@ -1,15 +1,23 @@
 import type { ActiveWorker, Task } from "./app.ts";
 import type { Call } from "./call.ts";
+import type { DemoJsonCodecContext } from "./demo-json-codec.ts";
 
 export interface Codec<C> {
   encodeCall<A extends unknown[]>(taskName: string, args: A): Promise<Call>;
 
-  invokeTask<A extends unknown[], R>(
-    call: Call,
-    task: Task<C, A, R>,
-    activeWorker: ActiveWorker<C>,
-    signal: Uint8Array,
-  ): Promise<Uint8Array>;
+  invokeTask<A extends unknown[], R>({
+    call,
+    task,
+    activeWorker,
+    signal,
+    metadata,
+  }: {
+    call: Call;
+    task: Task<C, A, R>;
+    activeWorker: ActiveWorker<C>;
+    signal: Uint8Array;
+    metadata: Uint8Array;
+  }): Promise<Uint8Array>;
 
   decodeReturn(taskName: string, payload: Uint8Array): unknown;
 }

--- a/typescript/src/connection.ts
+++ b/typescript/src/connection.ts
@@ -5,6 +5,7 @@ import { randomUUID } from "node:crypto";
 import type { Publisher, Subscriber } from "./emitter.ts";
 import { BrrrShutdownSymbol, BrrrTaskDoneEventSymbol } from "./symbol.ts";
 import { PendingReturn, ScheduleMessage, TaggedTuple } from "./tagged-tuple.ts";
+import { hex } from "./internal-codecs.ts";
 
 export interface DeferredCall {
   readonly topic: string | undefined;
@@ -78,7 +79,7 @@ export class Connection {
     const rootId = randomUUID().replaceAll("-", "");
     await this.putJob(
       topic,
-      new ScheduleMessage(rootId, call.callHash, metadata),
+      new ScheduleMessage(rootId, call.callHash, hex.encode(metadata)),
     );
     return rootId;
   }
@@ -126,7 +127,7 @@ export class Server extends Connection {
     const signal = await this.memory.getSignal(message.rootId);
     const call = await this.memory.getCall(message.callHash);
     const handled = await requestHandler(
-      { call, rootId: message.rootId, metadata: message.metadata },
+      { call, rootId: message.rootId, metadata: hex.decode(message.metadata) },
       this,
       signal,
     );
@@ -181,7 +182,12 @@ export class Server extends Connection {
   ): Promise<void> {
     await this.memory.setCall(child.call);
     // undefined (not empty) means "inherit the parent's metadata"
-    const metadata = child.metadata ?? parent.metadata;
+    let metadata: string;
+    if (child.metadata !== undefined) {
+      metadata = hex.encode(child.metadata);
+    } else {
+      metadata = parent.metadata;
+    }
     const callHash = child.call.callHash;
     const pendingReturn = new PendingReturn(
       parent.rootId,

--- a/typescript/src/connection.ts
+++ b/typescript/src/connection.ts
@@ -9,6 +9,7 @@ import { PendingReturn, ScheduleMessage, TaggedTuple } from "./tagged-tuple.ts";
 export interface DeferredCall {
   readonly topic: string | undefined;
   readonly call: Call;
+  readonly metadata: Uint8Array | undefined;
 }
 
 export class Defer {
@@ -32,6 +33,8 @@ export class Abandon {}
 
 export interface Request {
   readonly call: Call;
+  readonly rootId: string;
+  readonly metadata: Uint8Array;
 }
 
 export interface Response {
@@ -66,13 +69,17 @@ export class Connection {
   public async scheduleRaw(
     topic: string,
     call: Call,
+    metadata: Uint8Array,
   ): Promise<string | undefined> {
     if (await this.memory.hasValue(call.callHash)) {
       return;
     }
     await this.memory.setCall(call);
     const rootId = randomUUID().replaceAll("-", "");
-    await this.putJob(topic, new ScheduleMessage(rootId, call.callHash));
+    await this.putJob(
+      topic,
+      new ScheduleMessage(rootId, call.callHash, metadata),
+    );
     return rootId;
   }
 
@@ -82,10 +89,6 @@ export class Connection {
 
   public async setSignal(rootId: string, signal: Uint8Array): Promise<void> {
     await this.memory.setSignal(rootId, signal);
-  }
-
-  public async clearSignal(rootId: string): Promise<void> {
-    await this.memory.clearSignal(rootId);
   }
 }
 
@@ -122,7 +125,11 @@ export class Server extends Connection {
     const message = TaggedTuple.decodeFromString(ScheduleMessage, payload);
     const signal = await this.memory.getSignal(message.rootId);
     const call = await this.memory.getCall(message.callHash);
-    const handled = await requestHandler({ call }, this, signal);
+    const handled = await requestHandler(
+      { call, rootId: message.rootId, metadata: message.metadata },
+      this,
+      signal,
+    );
     if (handled instanceof Defer) {
       await Promise.all(
         handled.calls.map((child) => {
@@ -162,6 +169,7 @@ export class Server extends Connection {
     const job = new ScheduleMessage(
       pendingReturn.rootId,
       pendingReturn.callHash,
+      pendingReturn.metadata,
     );
     await this.putJob(pendingReturn.topic, job);
   }
@@ -172,18 +180,21 @@ export class Server extends Connection {
     parent: ScheduleMessage,
   ): Promise<void> {
     await this.memory.setCall(child.call);
+    // undefined (not empty) means "inherit the parent's metadata"
+    const metadata = child.metadata ?? parent.metadata;
     const callHash = child.call.callHash;
     const pendingReturn = new PendingReturn(
       parent.rootId,
       parent.callHash,
       topic,
+      parent.metadata,
     );
     const shouldSchedule = await this.memory.addPendingReturns(
       callHash,
       pendingReturn,
     );
     if (shouldSchedule) {
-      const job = new ScheduleMessage(parent.rootId, callHash);
+      const job = new ScheduleMessage(parent.rootId, callHash, metadata);
       await this.putJob(child.topic || topic, job);
     }
   }

--- a/typescript/src/demo-json-codec.ts
+++ b/typescript/src/demo-json-codec.ts
@@ -50,15 +50,22 @@ export class DemoJsonCodec implements Codec<DemoJsonCodecContext> {
     return { taskName, payload, callHash };
   }
 
-  public async invokeTask<A extends unknown[], R>(
-    call: Call,
-    handler: Task<DemoJsonCodecContext, A, R>,
-    activeWorker: DemoJsonCodecContext,
-    signal: Uint8Array,
-  ): Promise<Uint8Array> {
+  public async invokeTask<A extends unknown[], R>({
+    call,
+    task,
+    activeWorker,
+    signal,
+    metadata,
+  }: {
+    call: Call;
+    task: Task<DemoJsonCodecContext, A, R>;
+    activeWorker: DemoJsonCodecContext;
+    signal: Uint8Array;
+    metadata: Uint8Array;
+  }): Promise<Uint8Array> {
     const decoded = decoder.decode(call.payload);
     const args = this.json.parse(decoded) as A;
-    const result = await handler(activeWorker, ...args);
+    const result = await task(activeWorker, ...args);
     const resultJson = this.json.stringify(result);
     return encoder.encode(resultJson);
   }

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -44,7 +44,7 @@ export class TagMismatchError extends BrrrError {
 export class MalformedTaggedTupleError extends BrrrError {
   public constructor(clz: Tagged) {
     super(
-      `Malformed tagged tuple for ${clz.name}, expected ${clz.length} elements`,
+      `Malformed tagged tuple for ${clz.name}, expected ${clz.fields.length} elements`,
     );
   }
 }

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -44,7 +44,7 @@ export class TagMismatchError extends BrrrError {
 export class MalformedTaggedTupleError extends BrrrError {
   public constructor(clz: Tagged) {
     super(
-      `Malformed tagged tuple for ${clz.name}, expected ${clz.fields.length} elements`,
+      `Malformed tagged tuple for ${clz.name}, expected ${clz.length} elements`,
     );
   }
 }

--- a/typescript/src/internal-codecs.ts
+++ b/typescript/src/internal-codecs.ts
@@ -26,3 +26,25 @@ export const bencoder = {
  */
 export const encoder = new TextEncoder();
 export const decoder = new TextDecoder(encoding);
+
+/**
+ * Raw bytes are hex-encoded before they go on the wire.
+ *
+ * Bencode has no separate byte string type and brrr decodes bencode strings as
+ * UTF-8, which is lossy for arbitrary bytes, so byte-valued fields travel as
+ * their hex representation instead.
+ */
+export const hex = {
+  encode(data: Uint8Array): string {
+    return Buffer.from(data).toString("hex");
+  },
+  decode(data: string): Uint8Array {
+    // Buffer.from(_, "hex") stops at the first invalid character instead of
+    // failing, which would silently truncate; reject up front like Python's
+    // bytes.fromhex does.
+    if (!/^([0-9a-fA-F]{2})*$/.test(data)) {
+      throw new Error(`Not a hex string: ${JSON.stringify(data)}`);
+    }
+    return Uint8Array.from(Buffer.from(data, "hex"));
+  },
+} as const;

--- a/typescript/src/store.test.ts
+++ b/typescript/src/store.test.ts
@@ -28,7 +28,7 @@ await suite(import.meta.filename, async () => {
   await suite(PendingReturns.name, async () => {
     await test("Encoded payload can be encoded & decoded", async () => {
       const original = new PendingReturns(0, [
-        new PendingReturn("a", "b", "c"),
+        new PendingReturn("a", "b", "c", Uint8Array.of()),
       ]);
       const encoded = original.encode();
       const decoded = PendingReturns.decode(encoded);
@@ -38,7 +38,7 @@ await suite(import.meta.filename, async () => {
 
     await test("Encoded payload with undefined timestamp can be encoded & decoded", async () => {
       const original = new PendingReturns(undefined, [
-        new PendingReturn("a", "b", "c"),
+        new PendingReturn("a", "b", "c", Uint8Array.of()),
       ]);
       const encoded = original.encode();
       const decoded = PendingReturns.decode(encoded);
@@ -63,7 +63,12 @@ await suite(import.meta.filename, async () => {
           callHash: "test-pending-return-hash",
         } satisfies MemKey,
       },
-      newReturn: new PendingReturn("some-root", "some-parent", "some-topic"),
+      newReturn: new PendingReturn(
+        "some-root",
+        "some-parent",
+        "some-topic",
+        Uint8Array.of(),
+      ),
     } as const;
 
     beforeEach(async () => {
@@ -119,7 +124,12 @@ await suite(import.meta.filename, async () => {
 
       await test("simple cases to document & test shouldSchedule", async () => {
         const hash = "some-hash";
-        const base = new PendingReturn("root", "parent", "topic");
+        const base = new PendingReturn(
+          "root",
+          "parent",
+          "topic",
+          Uint8Array.of(),
+        );
 
         const cases = [
           // base case
@@ -127,13 +137,34 @@ await suite(import.meta.filename, async () => {
           // same one, shouldn't schedule again
           [hash, base, false],
           // different root, should schedule - it's a retry
-          [hash, new PendingReturn("diff-root", "parent", "topic"), true],
+          [
+            hash,
+            new PendingReturn("diff-root", "parent", "topic", Uint8Array.of()),
+            true,
+          ],
           // new callHash, new PR, should schedule
           ["diff-hash", base, true],
           // continuation, shouldn't schedule again
-          [hash, new PendingReturn("root", "parent", "diff-topic"), false],
-          [hash, new PendingReturn("root", "diff-parent", "topic"), false],
-          [hash, new PendingReturn("root", "diff-parent", "diff-topic"), false],
+          [
+            hash,
+            new PendingReturn("root", "parent", "diff-topic", Uint8Array.of()),
+            false,
+          ],
+          [
+            hash,
+            new PendingReturn("root", "diff-parent", "topic", Uint8Array.of()),
+            false,
+          ],
+          [
+            hash,
+            new PendingReturn(
+              "root",
+              "diff-parent",
+              "diff-topic",
+              Uint8Array.of(),
+            ),
+            false,
+          ],
         ] as const;
 
         for (const [hash, pr, shouldSchedule] of cases) {
@@ -202,6 +233,7 @@ await suite(import.meta.filename, async () => {
           "completely",
           "different",
           "return",
+          Uint8Array.of(),
         );
         const shouldSchedule = await memory.addPendingReturns(
           fixture.call.callHash,
@@ -229,6 +261,7 @@ await suite(import.meta.filename, async () => {
           "other-root",
           fixture.newReturn.callHash,
           fixture.newReturn.topic,
+          Uint8Array.of(),
         );
         const shouldSchedule = await memory.addPendingReturns(
           fixture.call.callHash,
@@ -253,8 +286,8 @@ await suite(import.meta.filename, async () => {
     await suite("withPendingReturnRemove", async () => {
       const mockFn =
         mock.fn<(returns: Iterable<PendingReturn>) => Promise<void>>();
-      const pendingReturn1 = new PendingReturn("a", "b", "c");
-      const pendingReturn2 = new PendingReturn("d", "e", "f");
+      const pendingReturn1 = new PendingReturn("a", "b", "c", Uint8Array.of());
+      const pendingReturn2 = new PendingReturn("d", "e", "f", Uint8Array.of());
 
       const unstableFn = mock.fn((returns: Iterable<PendingReturn>) => {
         const pendingReturns = new PendingReturns(undefined, [
@@ -278,8 +311,8 @@ await suite(import.meta.filename, async () => {
 
       await test("invokes f with pending returns and deletes the key", async () => {
         const pendingReturns = new PendingReturns(undefined, [
-          new PendingReturn("a", "b", "c"),
-          new PendingReturn("d", "e", "f"),
+          new PendingReturn("a", "b", "c", Uint8Array.of()),
+          new PendingReturn("d", "e", "f", Uint8Array.of()),
         ]);
         await store.set(fixture.pendingReturns.key, pendingReturns.encode());
         await memory.withPendingReturnsRemove(

--- a/typescript/src/store.test.ts
+++ b/typescript/src/store.test.ts
@@ -28,7 +28,7 @@ await suite(import.meta.filename, async () => {
   await suite(PendingReturns.name, async () => {
     await test("Encoded payload can be encoded & decoded", async () => {
       const original = new PendingReturns(0, [
-        new PendingReturn("a", "b", "c", Uint8Array.of()),
+        new PendingReturn("a", "b", "c", ""),
       ]);
       const encoded = original.encode();
       const decoded = PendingReturns.decode(encoded);
@@ -38,7 +38,7 @@ await suite(import.meta.filename, async () => {
 
     await test("Encoded payload with undefined timestamp can be encoded & decoded", async () => {
       const original = new PendingReturns(undefined, [
-        new PendingReturn("a", "b", "c", Uint8Array.of()),
+        new PendingReturn("a", "b", "c", ""),
       ]);
       const encoded = original.encode();
       const decoded = PendingReturns.decode(encoded);
@@ -67,7 +67,7 @@ await suite(import.meta.filename, async () => {
         "some-root",
         "some-parent",
         "some-topic",
-        Uint8Array.of(),
+        "",
       ),
     } as const;
 
@@ -124,12 +124,7 @@ await suite(import.meta.filename, async () => {
 
       await test("simple cases to document & test shouldSchedule", async () => {
         const hash = "some-hash";
-        const base = new PendingReturn(
-          "root",
-          "parent",
-          "topic",
-          Uint8Array.of(),
-        );
+        const base = new PendingReturn("root", "parent", "topic", "");
 
         const cases = [
           // base case
@@ -137,32 +132,15 @@ await suite(import.meta.filename, async () => {
           // same one, shouldn't schedule again
           [hash, base, false],
           // different root, should schedule - it's a retry
-          [
-            hash,
-            new PendingReturn("diff-root", "parent", "topic", Uint8Array.of()),
-            true,
-          ],
+          [hash, new PendingReturn("diff-root", "parent", "topic", ""), true],
           // new callHash, new PR, should schedule
           ["diff-hash", base, true],
           // continuation, shouldn't schedule again
+          [hash, new PendingReturn("root", "parent", "diff-topic", ""), false],
+          [hash, new PendingReturn("root", "diff-parent", "topic", ""), false],
           [
             hash,
-            new PendingReturn("root", "parent", "diff-topic", Uint8Array.of()),
-            false,
-          ],
-          [
-            hash,
-            new PendingReturn("root", "diff-parent", "topic", Uint8Array.of()),
-            false,
-          ],
-          [
-            hash,
-            new PendingReturn(
-              "root",
-              "diff-parent",
-              "diff-topic",
-              Uint8Array.of(),
-            ),
+            new PendingReturn("root", "diff-parent", "diff-topic", ""),
             false,
           ],
         ] as const;
@@ -233,7 +211,7 @@ await suite(import.meta.filename, async () => {
           "completely",
           "different",
           "return",
-          Uint8Array.of(),
+          "",
         );
         const shouldSchedule = await memory.addPendingReturns(
           fixture.call.callHash,
@@ -261,7 +239,7 @@ await suite(import.meta.filename, async () => {
           "other-root",
           fixture.newReturn.callHash,
           fixture.newReturn.topic,
-          Uint8Array.of(),
+          "",
         );
         const shouldSchedule = await memory.addPendingReturns(
           fixture.call.callHash,
@@ -286,8 +264,8 @@ await suite(import.meta.filename, async () => {
     await suite("withPendingReturnRemove", async () => {
       const mockFn =
         mock.fn<(returns: Iterable<PendingReturn>) => Promise<void>>();
-      const pendingReturn1 = new PendingReturn("a", "b", "c", Uint8Array.of());
-      const pendingReturn2 = new PendingReturn("d", "e", "f", Uint8Array.of());
+      const pendingReturn1 = new PendingReturn("a", "b", "c", "");
+      const pendingReturn2 = new PendingReturn("d", "e", "f", "");
 
       const unstableFn = mock.fn((returns: Iterable<PendingReturn>) => {
         const pendingReturns = new PendingReturns(undefined, [
@@ -311,8 +289,8 @@ await suite(import.meta.filename, async () => {
 
       await test("invokes f with pending returns and deletes the key", async () => {
         const pendingReturns = new PendingReturns(undefined, [
-          new PendingReturn("a", "b", "c", Uint8Array.of()),
-          new PendingReturn("d", "e", "f", Uint8Array.of()),
+          new PendingReturn("a", "b", "c", ""),
+          new PendingReturn("d", "e", "f", ""),
         ]);
         await store.set(fixture.pendingReturns.key, pendingReturns.encode());
         await memory.withPendingReturnsRemove(

--- a/typescript/src/store.ts
+++ b/typescript/src/store.ts
@@ -43,7 +43,7 @@ export class PendingReturns {
       [...new Set(returns)].map((it) => {
         return TaggedTuple.fromTuple(
           PendingReturn,
-          it as [number, string, string, string],
+          it as [number, ...unknown[]],
         );
       }),
     );

--- a/typescript/src/store.ts
+++ b/typescript/src/store.ts
@@ -43,7 +43,7 @@ export class PendingReturns {
       [...new Set(returns)].map((it) => {
         return TaggedTuple.fromTuple(
           PendingReturn,
-          it as [number, ...unknown[]],
+          it as [number, string, string, string, string],
         );
       }),
     );

--- a/typescript/src/tagged-tuple.test.ts
+++ b/typescript/src/tagged-tuple.test.ts
@@ -2,11 +2,12 @@ import { suite, test } from "node:test";
 import { deepStrictEqual, ok } from "node:assert/strict";
 import { throws } from "node:assert";
 import { MalformedTaggedTupleError, TagMismatchError } from "./errors.ts";
-import { TaggedTuple } from "./tagged-tuple.ts";
+import { bytesField, TaggedTuple } from "./tagged-tuple.ts";
 
 await suite(import.meta.filename, async () => {
   class Foo {
     public static readonly tag = 0;
+    public static readonly fields = ["bar", "baz"] as const;
 
     public readonly bar: number;
     public readonly baz: string;
@@ -32,14 +33,12 @@ await suite(import.meta.filename, async () => {
     });
     await test("too many args", async () => {
       throws(
-        // @ts-expect-error testing runtime error
         () => TaggedTuple.fromTuple(Foo, [0, 42, "hello", "a"]),
         MalformedTaggedTupleError,
       );
     });
     await test("too few args", async () => {
       throws(
-        // @ts-expect-error testing runtime error
         () => TaggedTuple.fromTuple(Foo, [0, 42]),
         MalformedTaggedTupleError,
       );
@@ -65,5 +64,41 @@ await suite(import.meta.filename, async () => {
     const encoded: string = TaggedTuple.encodeToString(foo);
     const decoded = TaggedTuple.decodeFromString(Foo, encoded);
     deepStrictEqual(decoded, foo);
+  });
+
+  await suite("bytes fields", async () => {
+    class Blob {
+      public static readonly tag = 7;
+      public static readonly fields = ["name", bytesField("data")] as const;
+
+      public readonly name: string;
+      public readonly data: Uint8Array;
+
+      public constructor(name: string, data: Uint8Array) {
+        this.name = name;
+        this.data = data;
+      }
+    }
+
+    // Not valid UTF-8, which is exactly why byte fields travel as hex.
+    const data = Uint8Array.of(0x00, 0xff, 0xfe, 0x80);
+
+    await test("go on the wire as hex", async () => {
+      deepStrictEqual(TaggedTuple.asTuple(new Blob("b", data)), [
+        7,
+        "b",
+        "00fffe80",
+      ]);
+    });
+
+    await test("round trip through encode and decode", async () => {
+      const original = new Blob("b", data);
+      const decoded = TaggedTuple.decode(Blob, TaggedTuple.encode(original));
+      deepStrictEqual(decoded, original);
+    });
+
+    await test("reject a non-hex payload instead of truncating it", async () => {
+      throws(() => TaggedTuple.fromTuple(Blob, [7, "b", "00ff8"]));
+    });
   });
 });

--- a/typescript/src/tagged-tuple.test.ts
+++ b/typescript/src/tagged-tuple.test.ts
@@ -2,12 +2,11 @@ import { suite, test } from "node:test";
 import { deepStrictEqual, ok } from "node:assert/strict";
 import { throws } from "node:assert";
 import { MalformedTaggedTupleError, TagMismatchError } from "./errors.ts";
-import { bytesField, TaggedTuple } from "./tagged-tuple.ts";
+import { TaggedTuple } from "./tagged-tuple.ts";
 
 await suite(import.meta.filename, async () => {
   class Foo {
     public static readonly tag = 0;
-    public static readonly fields = ["bar", "baz"] as const;
 
     public readonly bar: number;
     public readonly baz: string;
@@ -33,12 +32,14 @@ await suite(import.meta.filename, async () => {
     });
     await test("too many args", async () => {
       throws(
+        // @ts-expect-error testing runtime error
         () => TaggedTuple.fromTuple(Foo, [0, 42, "hello", "a"]),
         MalformedTaggedTupleError,
       );
     });
     await test("too few args", async () => {
       throws(
+        // @ts-expect-error testing runtime error
         () => TaggedTuple.fromTuple(Foo, [0, 42]),
         MalformedTaggedTupleError,
       );
@@ -64,41 +65,5 @@ await suite(import.meta.filename, async () => {
     const encoded: string = TaggedTuple.encodeToString(foo);
     const decoded = TaggedTuple.decodeFromString(Foo, encoded);
     deepStrictEqual(decoded, foo);
-  });
-
-  await suite("bytes fields", async () => {
-    class Blob {
-      public static readonly tag = 7;
-      public static readonly fields = ["name", bytesField("data")] as const;
-
-      public readonly name: string;
-      public readonly data: Uint8Array;
-
-      public constructor(name: string, data: Uint8Array) {
-        this.name = name;
-        this.data = data;
-      }
-    }
-
-    // Not valid UTF-8, which is exactly why byte fields travel as hex.
-    const data = Uint8Array.of(0x00, 0xff, 0xfe, 0x80);
-
-    await test("go on the wire as hex", async () => {
-      deepStrictEqual(TaggedTuple.asTuple(new Blob("b", data)), [
-        7,
-        "b",
-        "00fffe80",
-      ]);
-    });
-
-    await test("round trip through encode and decode", async () => {
-      const original = new Blob("b", data);
-      const decoded = TaggedTuple.decode(Blob, TaggedTuple.encode(original));
-      deepStrictEqual(decoded, original);
-    });
-
-    await test("reject a non-hex payload instead of truncating it", async () => {
-      throws(() => TaggedTuple.fromTuple(Blob, [7, "b", "00ff8"]));
-    });
   });
 });

--- a/typescript/src/tagged-tuple.ts
+++ b/typescript/src/tagged-tuple.ts
@@ -1,31 +1,72 @@
-import { bencoder, decoder, encoder, encoding } from "./internal-codecs.ts";
+import {
+  bencoder,
+  decoder,
+  encoder,
+  encoding,
+  hex,
+} from "./internal-codecs.ts";
 import { MalformedTaggedTupleError, TagMismatchError } from "./errors.ts";
+
+/**
+ * A single field of a tagged tuple, in wire order.
+ *
+ * A plain string is the property name of a field that bencode round-trips as
+ * is. `bytesField` marks a property holding raw bytes, which are hex-encoded
+ * on the wire. This is the counterpart of inspecting the declared field type
+ * on the Python side, which has no equivalent at runtime here.
+ */
+export type FieldSpec =
+  | string
+  | { readonly name: string; readonly bytes: true };
+
+export function bytesField(name: string) {
+  return { name, bytes: true } as const;
+}
+
+const nameOf = (field: FieldSpec): string =>
+  typeof field === "string" ? field : field.name;
+
+const isBytes = (field: FieldSpec): boolean => typeof field !== "string";
 
 export interface Tagged<T = any, A extends unknown[] = any[]> {
   new (...args: A): T;
 
   readonly tag: number;
+  readonly fields: readonly FieldSpec[];
 }
+
+// The wire representation is not `[number, ...A]`: byte-valued fields are hex
+// strings on the wire but Uint8Array in the constructor, so the slots don't
+// line up with the constructor's argument types.
+type WireTuple = readonly [number, ...unknown[]];
 
 function fromTuple<T, A extends unknown[]>(
   tagged: Tagged<T, A>,
-  data: [number, ...A],
+  data: WireTuple,
 ): InstanceType<typeof tagged> {
   if (data[0] !== tagged.tag) {
     throw new TagMismatchError(tagged);
   }
-  if (data.length - 1 !== tagged.length) {
+  if (data.length - 1 !== tagged.fields.length) {
     throw new MalformedTaggedTupleError(tagged);
   }
-  return new tagged(...(data.slice(1) as A));
+  const args = tagged.fields.map((field, i) => {
+    const val = data[i + 1];
+    return isBytes(field) ? hex.decode(val as string) : val;
+  });
+  return new tagged(...(args as A));
 }
 
 function asTuple<T extends object, A extends unknown[]>(
   obj: InstanceType<Tagged<T, A>>,
-): [number, ...A] {
-  return [(obj.constructor as Tagged<T, A>).tag, ...Object.values(obj)] as [
-    number,
-    ...A,
+): [number, ...unknown[]] {
+  const tagged = obj.constructor as Tagged<T, A>;
+  return [
+    tagged.tag,
+    ...tagged.fields.map((field) => {
+      const val = (obj as Record<string, unknown>)[nameOf(field)];
+      return isBytes(field) ? hex.encode(val as Uint8Array) : val;
+    }),
   ];
 }
 
@@ -41,7 +82,7 @@ function decode<T, A extends unknown[]>(
   tagged: Tagged<T, A>,
   data: Uint8Array,
 ): InstanceType<typeof tagged> {
-  const decoded = bencoder.decode(data, encoding) as [number, ...A];
+  const decoded = bencoder.decode(data, encoding) as WireTuple;
   return fromTuple(tagged, decoded);
 }
 
@@ -62,16 +103,29 @@ export const TaggedTuple = {
 } as const;
 
 export class PendingReturn {
-  public static readonly tag = 1;
+  public static readonly tag = 3;
+  public static readonly fields = [
+    "rootId",
+    "callHash",
+    "topic",
+    bytesField("metadata"),
+  ] as const;
 
   public readonly rootId: string;
   public readonly callHash: string;
   public readonly topic: string;
+  public readonly metadata: Uint8Array;
 
-  constructor(rootId: string, callHash: string, topic: string) {
+  constructor(
+    rootId: string,
+    callHash: string,
+    topic: string,
+    metadata: Uint8Array,
+  ) {
     this.rootId = rootId;
     this.callHash = callHash;
     this.topic = topic;
+    this.metadata = metadata;
   }
 
   public isRepeatedCall(other: PendingReturn): boolean {
@@ -84,13 +138,20 @@ export class PendingReturn {
 }
 
 export class ScheduleMessage {
-  public static readonly tag = 2;
+  public static readonly tag = 4;
+  public static readonly fields = [
+    "rootId",
+    "callHash",
+    bytesField("metadata"),
+  ] as const;
 
   public readonly rootId: string;
   public readonly callHash: string;
+  public readonly metadata: Uint8Array;
 
-  constructor(rootId: string, callHash: string) {
+  constructor(rootId: string, callHash: string, metadata: Uint8Array) {
     this.rootId = rootId;
     this.callHash = callHash;
+    this.metadata = metadata;
   }
 }

--- a/typescript/src/tagged-tuple.ts
+++ b/typescript/src/tagged-tuple.ts
@@ -1,72 +1,31 @@
-import {
-  bencoder,
-  decoder,
-  encoder,
-  encoding,
-  hex,
-} from "./internal-codecs.ts";
+import { bencoder, decoder, encoder, encoding } from "./internal-codecs.ts";
 import { MalformedTaggedTupleError, TagMismatchError } from "./errors.ts";
-
-/**
- * A single field of a tagged tuple, in wire order.
- *
- * A plain string is the property name of a field that bencode round-trips as
- * is. `bytesField` marks a property holding raw bytes, which are hex-encoded
- * on the wire. This is the counterpart of inspecting the declared field type
- * on the Python side, which has no equivalent at runtime here.
- */
-export type FieldSpec =
-  | string
-  | { readonly name: string; readonly bytes: true };
-
-export function bytesField(name: string) {
-  return { name, bytes: true } as const;
-}
-
-const nameOf = (field: FieldSpec): string =>
-  typeof field === "string" ? field : field.name;
-
-const isBytes = (field: FieldSpec): boolean => typeof field !== "string";
 
 export interface Tagged<T = any, A extends unknown[] = any[]> {
   new (...args: A): T;
 
   readonly tag: number;
-  readonly fields: readonly FieldSpec[];
 }
-
-// The wire representation is not `[number, ...A]`: byte-valued fields are hex
-// strings on the wire but Uint8Array in the constructor, so the slots don't
-// line up with the constructor's argument types.
-type WireTuple = readonly [number, ...unknown[]];
 
 function fromTuple<T, A extends unknown[]>(
   tagged: Tagged<T, A>,
-  data: WireTuple,
+  data: [number, ...A],
 ): InstanceType<typeof tagged> {
   if (data[0] !== tagged.tag) {
     throw new TagMismatchError(tagged);
   }
-  if (data.length - 1 !== tagged.fields.length) {
+  if (data.length - 1 !== tagged.length) {
     throw new MalformedTaggedTupleError(tagged);
   }
-  const args = tagged.fields.map((field, i) => {
-    const val = data[i + 1];
-    return isBytes(field) ? hex.decode(val as string) : val;
-  });
-  return new tagged(...(args as A));
+  return new tagged(...(data.slice(1) as A));
 }
 
 function asTuple<T extends object, A extends unknown[]>(
   obj: InstanceType<Tagged<T, A>>,
-): [number, ...unknown[]] {
-  const tagged = obj.constructor as Tagged<T, A>;
-  return [
-    tagged.tag,
-    ...tagged.fields.map((field) => {
-      const val = (obj as Record<string, unknown>)[nameOf(field)];
-      return isBytes(field) ? hex.encode(val as Uint8Array) : val;
-    }),
+): [number, ...A] {
+  return [(obj.constructor as Tagged<T, A>).tag, ...Object.values(obj)] as [
+    number,
+    ...A,
   ];
 }
 
@@ -82,7 +41,7 @@ function decode<T, A extends unknown[]>(
   tagged: Tagged<T, A>,
   data: Uint8Array,
 ): InstanceType<typeof tagged> {
-  const decoded = bencoder.decode(data, encoding) as WireTuple;
+  const decoded = bencoder.decode(data, encoding) as [number, ...A];
   return fromTuple(tagged, decoded);
 }
 
@@ -104,23 +63,17 @@ export const TaggedTuple = {
 
 export class PendingReturn {
   public static readonly tag = 3;
-  public static readonly fields = [
-    "rootId",
-    "callHash",
-    "topic",
-    bytesField("metadata"),
-  ] as const;
 
   public readonly rootId: string;
   public readonly callHash: string;
   public readonly topic: string;
-  public readonly metadata: Uint8Array;
+  public readonly metadata: string;
 
   constructor(
     rootId: string,
     callHash: string,
     topic: string,
-    metadata: Uint8Array,
+    metadata: string,
   ) {
     this.rootId = rootId;
     this.callHash = callHash;
@@ -139,17 +92,12 @@ export class PendingReturn {
 
 export class ScheduleMessage {
   public static readonly tag = 4;
-  public static readonly fields = [
-    "rootId",
-    "callHash",
-    bytesField("metadata"),
-  ] as const;
 
   public readonly rootId: string;
   public readonly callHash: string;
-  public readonly metadata: Uint8Array;
+  public readonly metadata: string;
 
-  constructor(rootId: string, callHash: string, metadata: Uint8Array) {
+  constructor(rootId: string, callHash: string, metadata: string) {
     this.rootId = rootId;
     this.callHash = callHash;
     this.metadata = metadata;


### PR DESCRIPTION
We need a way to pass out of band metadata from task to task. The current way of doing this is messing with the callhash which is very fraught. Instead we make metadata a first class citizen and allow users to pass it in via `schedule` and manipulate it via `invoke_task` in their custom codec.
Also the new metadata and signal params are very easy to mix up so I force named params for them.